### PR TITLE
Fix TypeScript build and tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-node_modules
-dist
-.mcp-nn
+node_modules/
+dist/
+.mcp-nn/
 .DS_Store
+npm-debug.log*

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 NarcoNations.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,153 @@
+# Local Research MCP (mcp-nn)
+
+Offline Model Context Protocol (MCP) server for NarcoNations.org research. Index and search PDF, Markdown, TXT, Word (.docx), and Apple Pages (.pages) files with hybrid retrieval (local embeddings + BM25). Returns precise citations (file, page, char ranges, snippet). 100% local. No cloud.
+
+## Quickstart
+
+### Requirements
+- Node.js 20+
+- macOS, Linux, or Windows
+
+```bash
+# 1) Install dependencies
+npm install
+
+# 2) (Optional) Prefetch the local embedding model for fully offline use
+npm run models:download
+
+# 3) Index your folders
+npm run index -- ./docs ./public/dossiers ./pdfs
+
+# 4) Run the MCP server (stdio)
+npm run dev
+```
+
+### Example MCP tool calls
+
+`search_local`
+
+```json
+{
+  "tool": "search_local",
+  "input": { "query": "Antwerp cocaine port", "k": 8, "alpha": 0.65 }
+}
+```
+
+`get_doc`
+
+```json
+{
+  "tool": "get_doc",
+  "input": { "path": "./docs/ports/antwerp.pdf", "page": 12 }
+}
+```
+
+## ChatGPT → ZIP → Markdown → Index
+
+1. Export chats from ChatGPT (Profile → Settings → Data Controls → Export data) and unzip locally.
+2. Convert to Markdown:
+   ```bash
+   npm run chatgpt:to-md -- ~/Downloads/chatgpt-export
+   # → writes .md files into ./docs/chatgpt-export-md
+   ```
+3. Index the converted chats:
+   ```bash
+   npm run index -- ./docs/chatgpt-export-md
+   ```
+4. Search in your MCP client:
+   ```json
+   { "tool": "search_local", "input": { "query": "Antwerp cocaine port" } }
+   ```
+
+Optional one-shot tool call:
+
+```json
+{
+  "tool": "import_chatgpt_export",
+  "input": {
+    "exportPath": "~/Downloads/chatgpt-export",
+    "outDir": "./docs/chatgpt-export-md"
+  }
+}
+```
+
+## Configuration
+
+`./.mcp-nn/config.json` is created on first run. Defaults:
+
+```json
+{
+  "roots": {
+    "roots": ["./docs", "./public/dossiers", "./docs/chatgpt-export-md"],
+    "include": [".pdf", ".md", ".txt", ".docx", ".pages"],
+    "exclude": ["**/node_modules/**", ".git/**"]
+  },
+  "index": {
+    "chunkSize": 3500,
+    "chunkOverlap": 120,
+    "ocrEnabled": true,
+    "ocrTriggerMinChars": 100,
+    "useSQLiteVSS": false,
+    "model": "Xenova/all-MiniLM-L6-v2",
+    "maxFileSizeMB": 200,
+    "concurrency": 2,
+    "languages": ["eng"]
+  },
+  "out": { "dataDir": ".mcp-nn" }
+}
+```
+
+Environment overrides:
+
+- `MCP_NN_DATA_DIR` – change index storage directory.
+- `TRANSFORMERS_CACHE` – set Xenova model cache directory.
+- `TRANSFORMERS_OFFLINE=1` – enforce offline model loading.
+
+## File Types & Caveats
+
+- **PDF**: Uses `pdf-parse`. If a page has scarce text, it is marked `partial: true` and logged for manual OCR.
+- **Markdown**: Front-matter parsed via `gray-matter`; tags preserved per chunk.
+- **Text**: Plain UTF-8 with whitespace normalization.
+- **Word (.docx)**: Extracted with `mammoth` (styles ignored).
+- **Pages (.pages)**: Parsed via `adm-zip` + `fast-xml-parser`. Modern `.iwa` bundles fall back to partial mode (file is logged, indexing continues).
+
+## Performance Tips
+
+- First MiniLM model load on CPU takes ~10–30s, then uses the cached weights.
+- Increase `index.chunkSize` for larger documents or decrease overlap for smaller corpora.
+- Disable OCR (`index.ocrEnabled=false`) when all PDFs are digitally native.
+- For corpora above ~50k chunks, consider enabling SQLite-VSS once available.
+
+## Security & Privacy
+
+- Strict root whitelist with realpath normalization; symlink escapes and ZipSlip paths are rejected.
+- All processing stays local. No outbound network calls.
+- ChatGPT exports may contain sensitive information—keep within trusted directories.
+
+## Troubleshooting
+
+- **Slow OCR**: Raise `ocrTriggerMinChars` or disable OCR for digital PDFs.
+- **Model load errors offline**: Run `npm run models:download` and set `TRANSFORMERS_OFFLINE=1`.
+- **sqlite-vss missing**: Ignored automatically; flat vector index remains active.
+- **Pages file marked partial**: Export the Pages document to `.docx` or `.pdf` and reindex.
+- **ChatGPT conversion fails**: Ensure `conversations.json` exists in the provided folder.
+
+## Tests
+
+```bash
+npm test
+```
+
+Runs Vitest offline. Embedding operations are mocked by cached vectors; real-model tests require `npm run models:download` beforehand.
+
+## Styling & Conventions
+
+- TypeScript strict mode; prefer small, pure functions.
+- Function names use `verbNoun`, types use `PascalCase`.
+- Comments explain reasoning, not mechanics.
+- Logging emits single-line JSON (`{ level, msg, meta }`); stacks appear only in debug/development modes.
+- Validate MCP tool inputs with Zod and return deterministic JSON outputs.
+
+## License
+
+Released under the MIT License. See [LICENSE](./LICENSE).

--- a/fixtures/chatgpt-export-sample/conversations.json
+++ b/fixtures/chatgpt-export-sample/conversations.json
@@ -1,0 +1,22 @@
+[
+  {
+    "id": "sample-conv",
+    "title": "Sample Chat",
+    "create_time": 1700000000,
+    "model_slug": "gpt-4",
+    "messages": [
+      {
+        "id": "msg-1",
+        "author": { "role": "user" },
+        "create_time": 1700000000,
+        "content": { "parts": ["Hello there"] }
+      },
+      {
+        "id": "msg-2",
+        "author": { "role": "assistant" },
+        "create_time": 1700000001,
+        "content": { "parts": ["General Kenobi"] }
+      }
+    ]
+  }
+]

--- a/fixtures/docs/sample.md
+++ b/fixtures/docs/sample.md
@@ -1,0 +1,13 @@
+---
+title: Sample Markdown
+tags:
+  - test
+  - sample
+---
+
+# Heading
+
+This is a sample markdown document with enough text to create multiple chunks.
+It discusses Antwerp and cocaine trafficking in the port.
+
+Additional paragraph to ensure chunk overlap behaviour.

--- a/fixtures/docs/sample.txt
+++ b/fixtures/docs/sample.txt
@@ -1,0 +1,3 @@
+This is a plain text file.
+It contains insights about Antwerp's port security and cocaine interdiction.
+The purpose is to validate text indexer functionality.

--- a/mcp.json
+++ b/mcp.json
@@ -1,0 +1,17 @@
+{
+  "name": "mcp-nn",
+  "version": "1.1.0",
+  "transport": {
+    "type": "stdio",
+    "command": "node",
+    "args": ["./dist/server.js"]
+  },
+  "tools": [
+    "search_local",
+    "get_doc",
+    "reindex",
+    "watch",
+    "stats",
+    "import_chatgpt_export"
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "mcp-nn",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-nn",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "ISC",
       "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.18.1",
         "@xenova/transformers": "^2.17.2",
         "adm-zip": "^0.5.16",
         "chokidar": "^4.0.3",
@@ -30,7 +31,6 @@
         "@types/uuid": "^10.0.0",
         "rimraf": "^6.0.1",
         "ts-node": "^10.9.2",
-        "tsx": "^4.20.5",
         "typescript": "^5.9.2",
         "vitest": "^3.2.4"
       },
@@ -633,6 +633,47 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.18.1.tgz",
+      "integrity": "sha512-d//GE8/Yh7aC3e7p+kZG8JqqEAwwDUmAfvH1quogtbk+ksS6E0RR6toKKESPYYZVre0meqkJb27zb+dhqE9Sgw==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.6",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.0.1",
+        "express-rate-limit": "^7.5.0",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.23.8",
+        "zod-to-json-schema": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/zod-to-json-schema": {
+      "version": "3.24.6",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
+      "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.24.1"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -1331,6 +1372,28 @@
       "license": "ISC",
       "optional": true
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -1422,6 +1485,22 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/ansi-regex": {
@@ -1682,6 +1761,43 @@
       "integrity": "sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw==",
       "license": "MIT"
     },
+    "node_modules/body-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
+      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.0",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.6.3",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.0",
+        "raw-body": "^3.0.0",
+        "type-is": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/body-parser/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -1734,6 +1850,15 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "license": "MIT"
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/cac": {
       "version": "6.7.14",
@@ -1800,6 +1925,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/chai": {
@@ -1925,11 +2079,83 @@
       "license": "ISC",
       "optional": true
     },
+    "node_modules/content-disposition": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
+      "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-disposition/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/create-require": {
       "version": "1.1.1",
@@ -1942,7 +2168,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -2003,6 +2228,15 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.0.tgz",
@@ -2037,11 +2271,31 @@
         "underscore": "^1.13.1"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
     },
     "node_modules/emoji-regex": {
@@ -2050,6 +2304,15 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/encoding": {
       "version": "0.1.13",
@@ -2087,12 +2350,42 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.25.10",
@@ -2136,6 +2429,12 @@
         "@esbuild/win32-x64": "0.25.10"
       }
     },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -2159,6 +2458,36 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/expand-template": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
@@ -2178,6 +2507,80 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/express": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
+      "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.0",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
+      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/express/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/extend-shallow": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
@@ -2189,6 +2592,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
     },
     "node_modules/fast-fifo": {
       "version": "1.3.2",
@@ -2211,6 +2620,12 @@
       "engines": {
         "node": ">=8.6.0"
       }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "license": "MIT"
     },
     "node_modules/fast-xml-parser": {
       "version": "5.2.5",
@@ -2256,6 +2671,40 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
+      "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/finalhandler/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/flatbuffers": {
@@ -2322,6 +2771,24 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -2363,6 +2830,15 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gauge": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
@@ -2384,12 +2860,51 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/get-tsconfig": {
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
       "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
       },
@@ -2437,6 +2952,18 @@
         "node": ">= 6"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -2465,6 +2992,18 @@
       "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==",
       "license": "ISC"
     },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
@@ -2472,12 +3011,49 @@
       "license": "ISC",
       "optional": true
     },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/http-cache-semantics": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
       "license": "BSD-2-Clause",
       "optional": true
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-errors/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/http-proxy-agent": {
       "version": "4.0.1",
@@ -2559,7 +3135,6 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -2660,6 +3235,15 @@
         "node": ">= 12"
       }
     },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
@@ -2722,6 +3306,12 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/is-url": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
@@ -2738,7 +3328,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/jackspeak": {
@@ -2776,6 +3365,12 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "license": "MIT"
     },
     "node_modules/jszip": {
       "version": "3.10.1",
@@ -2913,6 +3508,36 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -2933,6 +3558,27 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/mimic-response": {
@@ -3245,6 +3891,39 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -3342,6 +4021,15 @@
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
       "license": "(MIT AND Zlib)"
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -3355,7 +4043,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3396,6 +4083,16 @@
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/pathe": {
@@ -3445,6 +4142,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.0.tgz",
+      "integrity": "sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/platform": {
@@ -3603,6 +4309,19 @@
         "pbts": "bin/pbts"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/pump": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
@@ -3611,6 +4330,30 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/queue-microtask": {
@@ -3632,6 +4375,46 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.1.tgz",
+      "integrity": "sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.7.0",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
+      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/rc": {
       "version": "1.2.8",
@@ -3688,6 +4471,8 @@
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
@@ -3824,6 +4609,39 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -3857,8 +4675,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/section-matter": {
       "version": "1.0.0",
@@ -3885,6 +4702,60 @@
         "node": ">=10"
       }
     },
+    "node_modules/send": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
+      "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "mime-types": "^3.0.1",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/send/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -3897,6 +4768,12 @@
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
       "license": "MIT"
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
     },
     "node_modules/sharp": {
       "version": "0.32.6",
@@ -3925,7 +4802,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -3938,10 +4814,81 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/siginfo": {
@@ -4157,6 +5104,15 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/std-env": {
       "version": "3.9.0",
@@ -4488,6 +5444,15 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -4544,6 +5509,8 @@
       "integrity": "sha512-+wKjMNU9w/EaQayHXb7WA7ZaHY6hN8WgfvHNQ3t1PnU91/7O8TcTnIhCDYTZwnt8JsO9IBqZ30Ln1r7pPF52Aw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.25.0",
         "get-tsconfig": "^4.7.5"
@@ -4568,6 +5535,20 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/typescript": {
@@ -4616,6 +5597,24 @@
         "imurmurhash": "^0.1.4"
       }
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -4641,6 +5640,15 @@
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/vite": {
       "version": "7.1.6",
@@ -4919,7 +5927,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -1,17 +1,20 @@
 {
   "name": "mcp-nn",
-  "version": "1.0.0",
-  "main": "index.js",
+  "version": "1.1.0",
+  "main": "dist/server.js",
   "scripts": {
     "test": "vitest run",
-    "dev": "tsx src/server.ts",
+    "dev": "ts-node src/server.ts",
     "start": "node --enable-source-maps dist/server.js",
     "build": "tsc -p tsconfig.json",
     "index": "ts-node src/cli-index.ts",
     "watch": "ts-node src/cli-watch.ts",
     "models:download": "node scripts/prefetch-model.mjs",
     "clean": "rimraf .mcp-nn dist",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "chatgpt:to-md": "ts-node scripts/chatgpt-export-to-md.ts",
+    "chatgpt:index": "ts-node scripts/chatgpt-export-to-md.ts ./fixtures/chatgpt-export-sample && ts-node src/cli-index.ts ./docs/chatgpt-export-md",
+    "chatgpt:quickstart": "npm run chatgpt:to-md -- ~/Downloads/chatgpt-export && npm run index -- ./docs/chatgpt-export-md"
   },
   "keywords": [],
   "author": "",
@@ -26,6 +29,7 @@
     "transpileOnly": "true"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.18.1",
     "@xenova/transformers": "^2.17.2",
     "adm-zip": "^0.5.16",
     "chokidar": "^4.0.3",
@@ -50,7 +54,6 @@
     "@types/uuid": "^10.0.0",
     "rimraf": "^6.0.1",
     "ts-node": "^10.9.2",
-    "tsx": "^4.20.5",
     "typescript": "^5.9.2",
     "vitest": "^3.2.4"
   }

--- a/scripts/chatgpt-export-to-md.ts
+++ b/scripts/chatgpt-export-to-md.ts
@@ -1,0 +1,148 @@
+// scripts/chatgpt-export-to-md.ts
+// Usage: npm run chatgpt:to-md -- /path/to/ChatGPT-export [outDir]
+import { promises as fs } from "fs";
+import path from "path";
+import crypto from "crypto";
+import { pathToFileURL } from "url";
+
+type AnyMsg = any;
+type AnyConv = any;
+type Message = { role: string; text: string; ts?: number };
+
+const outDirDefault = path.join(process.cwd(), "docs", "chatgpt-export-md");
+const toISO = (n?: number) => (n ? new Date(n > 2e10 ? n : n * 1000).toISOString() : new Date().toISOString());
+
+const slug = (s: string) =>
+  (s || "untitled")
+    .toLowerCase()
+    .replace(/[^\w\-]+/g, "-")
+    .replace(/\-+/g, "-")
+    .replace(/(^\-|\-$)/g, "")
+    .slice(0, 80) || "untitled";
+
+function asText(content: any): string {
+  if (!content) return "";
+  if (Array.isArray(content)) {
+    const parts = content.map((c: any) => c?.text?.value ?? c?.string_value ?? "").filter(Boolean);
+    if (parts.length) return parts.join("\n\n");
+  }
+  if (content?.parts && Array.isArray(content.parts)) return content.parts.join("\n\n");
+  if (typeof content === "string") return content;
+  return JSON.stringify(content, null, 2);
+}
+
+function extractMessages(conv: AnyConv): Message[] {
+  if (Array.isArray(conv?.messages)) {
+    return conv.messages
+      .map((m: AnyMsg) => ({
+        role: m?.author?.role || m?.role || "unknown",
+        text: asText(m?.content || m?.text),
+        ts: m?.create_time || m?.timestamp || m?.create_time_ms,
+      }))
+      .filter((m: Message) => m.text.trim());
+  }
+  if (conv?.mapping && typeof conv.mapping === "object") {
+    const msgs = Object.values(conv.mapping)
+      .map((n: any) => n?.message)
+      .filter(Boolean)
+      .map((m: any) => ({
+        role: m?.author?.role || m?.role || "unknown",
+        text: asText(m?.content),
+        ts: m?.create_time || m?.timestamp || m?.create_time_ms,
+      }))
+      .filter((m: Message) => m.text.trim());
+    return msgs.sort((a, b) => (a.ts ?? 0) - (b.ts ?? 0));
+  }
+  if (conv?.conversation?.messages) return extractMessages(conv.conversation);
+  return [];
+}
+
+async function loadExportJson(exportRoot: string): Promise<any> {
+  const candidates = [
+    path.join(exportRoot, "conversations.json"),
+    path.join(exportRoot, "conversations", "conversations.json"),
+    path.join(exportRoot, "export.json"),
+  ];
+  for (const p of candidates) {
+    try {
+      const raw = await fs.readFile(p, "utf8");
+      console.log(JSON.stringify({ level: "info", msg: "using_export_json", meta: { path: p } }));
+      return JSON.parse(raw);
+    } catch {}
+  }
+  throw new Error(`Could not find conversations.json in ${exportRoot}`);
+}
+
+async function ensureDir(p: string) {
+  await fs.mkdir(p, { recursive: true });
+}
+
+export async function convertChatGPTExport(exportRoot: string, outDirArg?: string) {
+  const data = await loadExportJson(exportRoot);
+  const conversations: AnyConv[] = Array.isArray(data) ? data : data.conversations ?? [];
+  if (!Array.isArray(conversations) || conversations.length === 0) {
+    throw new Error("No conversations found in export");
+  }
+
+  const outDir = outDirArg || outDirDefault;
+  await ensureDir(outDir);
+
+  let written = 0;
+  for (const conv of conversations) {
+    const id: string = conv.id || conv.conversation_id || crypto.randomBytes(6).toString("hex");
+    const title: string = (conv.title || conv.gist || "Untitled").trim();
+    const created: number = conv.create_time || conv.create_time_unix || conv.create_time_ms || Date.now();
+    const model: string = conv.model_slug || conv.model || "";
+    const msgs = extractMessages(conv);
+
+    const header = [
+      "---",
+      `id: ${JSON.stringify(id)}`,
+      `title: ${JSON.stringify(title)}`,
+      `created: ${JSON.stringify(toISO(created))}`,
+      `model: ${JSON.stringify(model)}`,
+      `source: "chatgpt-export"`,
+      "---",
+      "",
+      `# ${title}`,
+      "",
+    ].join("\n");
+
+    const body = msgs
+      .map(m => {
+        const role = m.role === "system" ? "system" : m.role?.replace(/^assistant$/, "assistant").replace(/^user$/, "user");
+        const when = m.ts ? toISO(m.ts) : "";
+        const text = (m.text || "").normalize("NFKC").trim();
+        return `## ${role}${when ? ` • ${when}` : ""}\n\n${text}\n`;
+      })
+      .join("\n");
+
+    const fname = `${slug(title)}-${id.slice(0, 8)}.md`;
+    await fs.writeFile(path.join(outDir, fname), `${header}${body}`, "utf8");
+    written++;
+  }
+
+  return { conversations: conversations.length, filesWritten: written, outDir };
+}
+
+async function main() {
+  const argIdx = process.argv.findIndex(a => a === "--");
+  const exportRoot = process.argv[argIdx >= 0 ? argIdx + 1 : 2] as string | undefined;
+  const outDirArg = process.argv[argIdx >= 0 ? argIdx + 2 : 3] as string | undefined;
+  if (!exportRoot) {
+    console.error("Usage: npm run chatgpt:to-md -- /path/to/ChatGPT-export [outDir]");
+    process.exit(1);
+  }
+  try {
+    const result = await convertChatGPTExport(exportRoot, outDirArg);
+    console.log(JSON.stringify({ level: "info", msg: "chatgpt_export_converted", meta: result }));
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  }
+}
+
+const isCli = process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url;
+if (isCli) {
+  main();
+}

--- a/src/cli-index.ts
+++ b/src/cli-index.ts
@@ -1,1 +1,18 @@
-console.log(JSON.stringify({ level: 'info', msg: 'index CLI stub — Codex will implement reindex(paths...)' }));
+#!/usr/bin/env node
+import { reindexPaths } from "./store/store.js";
+import { createLogger } from "./utils/logger.js";
+
+const logger = createLogger("cli-index");
+
+async function main() {
+  const args = process.argv.slice(2).filter(arg => arg !== "--");
+  const paths = args.length ? args : undefined;
+  const result = await reindexPaths(paths);
+  logger.info("reindex_complete", { ...result });
+  console.log(JSON.stringify(result));
+}
+
+main().catch(err => {
+  logger.error("reindex_failed", { error: err instanceof Error ? err.message : String(err) });
+  process.exit(1);
+});

--- a/src/cli-watch.ts
+++ b/src/cli-watch.ts
@@ -1,1 +1,24 @@
-console.log(JSON.stringify({ level: 'info', msg: 'watch CLI stub — Codex will implement chokidar + events' }));
+#!/usr/bin/env node
+import { createWatcher } from "./tools/watch.js";
+import { createLogger } from "./utils/logger.js";
+
+const logger = createLogger("cli-watch");
+
+async function main() {
+  const args = process.argv.slice(2).filter(arg => arg !== "--");
+  const watcher = await createWatcher({ paths: args }, event => {
+    logger.info("watch_event", event);
+  });
+  logger.info("watch_started", { paths: args.length ? args : "config.roots" });
+  process.stdin.resume();
+  process.on("SIGINT", () => {
+    watcher.close();
+    logger.info("watch_stopped");
+    process.exit(0);
+  });
+}
+
+main().catch(err => {
+  logger.error("watch_failed", { error: err instanceof Error ? err.message : String(err) });
+  process.exit(1);
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,84 @@
+import { promises as fs } from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import { AppConfig } from "./types.js";
+import { ensureDir } from "./utils/fs-guard.js";
+import { createLogger } from "./utils/logger.js";
+
+const logger = createLogger("config");
+
+const DEFAULT_CONFIG: AppConfig = {
+  roots: {
+    roots: ["./docs", "./public/dossiers", "./docs/chatgpt-export-md"],
+    include: [".pdf", ".md", ".txt", ".docx", ".pages"],
+    exclude: ["**/node_modules/**", ".git/**"],
+  },
+  index: {
+    chunkSize: 3500,
+    chunkOverlap: 120,
+    ocrEnabled: true,
+    ocrTriggerMinChars: 100,
+    useSQLiteVSS: false,
+    model: "Xenova/all-MiniLM-L6-v2",
+    maxFileSizeMB: 200,
+    concurrency: 2,
+    languages: ["eng"],
+  },
+  out: {
+    dataDir: ".mcp-nn",
+  },
+};
+
+function resolveDataDir(configDir: string): string {
+  if (process.env.MCP_NN_DATA_DIR) {
+    return path.resolve(process.cwd(), process.env.MCP_NN_DATA_DIR);
+  }
+  return path.resolve(process.cwd(), configDir);
+}
+
+export async function loadConfig(): Promise<AppConfig> {
+  const dataDir = resolveDataDir(DEFAULT_CONFIG.out.dataDir);
+  const dataConfigPath = path.join(dataDir, "config.json");
+
+  await ensureDir(dataDir);
+
+  let config: AppConfig = {
+    ...DEFAULT_CONFIG,
+    out: {
+      ...DEFAULT_CONFIG.out,
+      dataDir,
+      modelCacheDir: process.env.TRANSFORMERS_CACHE
+        ? path.resolve(process.env.TRANSFORMERS_CACHE)
+        : undefined,
+    },
+  };
+
+  try {
+    const raw = await fs.readFile(dataConfigPath, "utf8");
+    config = { ...config, ...JSON.parse(raw) };
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      logger.warn("config_read_failed", { error: String(err) });
+    }
+  }
+
+  if (process.env.MCP_NN_ROOTS) {
+    const roots = process.env.MCP_NN_ROOTS.split(path.delimiter).filter(Boolean);
+    if (roots.length) {
+      config = { ...config, roots: { ...config.roots, roots } };
+    }
+  }
+
+  await fs.writeFile(dataConfigPath, JSON.stringify(config, null, 2), "utf8");
+
+  return config;
+}
+
+export function getModelCacheDir(config: AppConfig): string | undefined {
+  if (config.out.modelCacheDir) return config.out.modelCacheDir;
+  const cache = process.env.TRANSFORMERS_CACHE;
+  return cache ? path.resolve(cache) : undefined;
+}
+
+export const PROJECT_ROOT = path.resolve(process.cwd());
+export const SRC_DIR = path.dirname(fileURLToPath(import.meta.url));

--- a/src/indexers/index.ts
+++ b/src/indexers/index.ts
@@ -1,0 +1,31 @@
+import path from "path";
+import type { Chunk } from "../types.js";
+import type { IndexerArgs, IndexerFn } from "./types.js";
+import { indexMarkdown } from "./markdown.js";
+import { indexPdf } from "./pdf.js";
+import { indexPages } from "./pages.js";
+import { indexText } from "./text.js";
+import { indexWord } from "./word.js";
+
+const indexers: Record<string, IndexerFn> = {
+  ".pdf": indexPdf,
+  ".md": indexMarkdown,
+  ".markdown": indexMarkdown,
+  ".txt": indexText,
+  ".docx": indexWord,
+  ".pages": indexPages,
+};
+
+export function getIndexer(filePath: string): IndexerFn {
+  const ext = path.extname(filePath).toLowerCase();
+  const indexer = indexers[ext];
+  if (!indexer) {
+    throw new Error(`No indexer for extension ${ext}`);
+  }
+  return indexer;
+}
+
+export async function runIndexer(args: IndexerArgs): Promise<Chunk[]> {
+  const indexer = getIndexer(args.filePath);
+  return indexer(args);
+}

--- a/src/indexers/markdown.ts
+++ b/src/indexers/markdown.ts
@@ -1,0 +1,26 @@
+import { promises as fs } from "fs";
+import matter from "gray-matter";
+import { chunkText } from "../pipeline/chunk.js";
+import { Chunk } from "../types.js";
+import { IndexerArgs } from "./types.js";
+
+export async function indexMarkdown({ filePath, mtime, config }: IndexerArgs): Promise<Chunk[]> {
+  const raw = await fs.readFile(filePath, "utf8");
+  const parsed = matter(raw);
+  const tags = Array.isArray(parsed.data?.tags)
+    ? parsed.data.tags.map((t: unknown) => String(t))
+    : undefined;
+  const chunks = chunkText(parsed.content, {
+    path: filePath,
+    type: "markdown",
+    page: undefined,
+    tags,
+    size: config.index.chunkSize,
+    overlap: config.index.chunkOverlap,
+    mtime,
+  });
+  for (const chunk of chunks) {
+    if (tags && tags.length) chunk.tags = tags;
+  }
+  return chunks;
+}

--- a/src/indexers/pages.ts
+++ b/src/indexers/pages.ts
@@ -1,0 +1,75 @@
+import AdmZip from "adm-zip";
+import { XMLParser } from "fast-xml-parser";
+import { chunkText } from "../pipeline/chunk.js";
+import { Chunk } from "../types.js";
+import { createLogger } from "../utils/logger.js";
+import { IndexerArgs } from "./types.js";
+
+const logger = createLogger("pages");
+
+const xmlParser = new XMLParser({
+  ignoreAttributes: false,
+  ignoreDeclaration: true,
+  trimValues: true,
+});
+
+function collectText(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) return value.map(collectText).join("\n");
+  if (value && typeof value === "object") {
+    return Object.values(value)
+      .map(collectText)
+      .join("\n");
+  }
+  return "";
+}
+
+export async function indexPages({ filePath, mtime, config }: IndexerArgs): Promise<Chunk[]> {
+  const zip = new AdmZip(filePath);
+  const entries = zip.getEntries();
+  let xmlText = "";
+  let partial = false;
+
+  for (const entry of entries) {
+    const name = entry.entryName;
+    if (name.includes("..") || name.startsWith("/")) {
+      logger.warn("pages_zip_escape_blocked", { file: filePath, entry: name });
+      continue;
+    }
+    if (name.endsWith(".xml")) {
+      const content = entry.getData().toString("utf8");
+      try {
+        const parsed = xmlParser.parse(content);
+        xmlText += `\n${collectText(parsed)}`;
+      } catch (err) {
+        logger.warn("pages_xml_parse_failed", { file: filePath, entry: name, error: String(err) });
+      }
+    }
+  }
+
+  if (!xmlText.trim()) {
+    partial = true;
+    logger.warn("pages_modern_partial", { file: filePath });
+  }
+
+  const text = xmlText.trim();
+  if (!text) {
+    return chunkText("", {
+      path: filePath,
+      type: "pages",
+      size: config.index.chunkSize,
+      overlap: config.index.chunkOverlap,
+      mtime,
+      partial: true,
+    });
+  }
+
+  return chunkText(text, {
+    path: filePath,
+    type: "pages",
+    size: config.index.chunkSize,
+    overlap: config.index.chunkOverlap,
+    mtime,
+    partial,
+  });
+}

--- a/src/indexers/pdf.ts
+++ b/src/indexers/pdf.ts
@@ -1,0 +1,52 @@
+import { promises as fs } from "fs";
+import pdfParse from "pdf-parse";
+import { chunkText } from "../pipeline/chunk.js";
+import { shouldRunOcr } from "../pipeline/detect-ocr.js";
+import { Chunk } from "../types.js";
+import { createLogger } from "../utils/logger.js";
+import { IndexerArgs } from "./types.js";
+
+const logger = createLogger("pdf");
+
+type PdfPage = {
+  getTextContent: (options?: { normalizeWhitespace?: boolean }) => Promise<{ items: Array<{ str?: string }> }>;
+};
+
+export async function indexPdf({ filePath, mtime, config }: IndexerArgs): Promise<Chunk[]> {
+  const buffer = await fs.readFile(filePath);
+  const pageTexts: string[] = [];
+
+  await pdfParse(buffer, {
+    pagerender: async (pageData: PdfPage) => {
+      const textContent = await pageData.getTextContent({ normalizeWhitespace: true });
+      const strings = textContent.items.map((item: { str?: string }) => item.str ?? "").join(" ");
+      pageTexts.push(strings);
+      return strings;
+    },
+  });
+
+  if (!pageTexts.length) {
+    logger.warn("pdf_no_pages", { file: filePath });
+    return [];
+  }
+
+  const chunks: Chunk[] = [];
+  pageTexts.forEach((pageText, index) => {
+    const needsOcr = shouldRunOcr(pageText, config.index);
+    if (needsOcr) {
+      logger.warn("pdf_ocr_not_implemented", { file: filePath, page: index + 1 });
+    }
+    const pageChunks = chunkText(pageText, {
+      path: filePath,
+      type: "pdf",
+      page: index + 1,
+      size: config.index.chunkSize,
+      overlap: config.index.chunkOverlap,
+      mtime,
+      partial: needsOcr,
+    });
+    chunks.push(...pageChunks);
+  });
+
+  return chunks;
+}

--- a/src/indexers/text.ts
+++ b/src/indexers/text.ts
@@ -1,0 +1,16 @@
+import { promises as fs } from "fs";
+import { chunkText, normalizeText } from "../pipeline/chunk.js";
+import { Chunk } from "../types.js";
+import { IndexerArgs } from "./types.js";
+
+export async function indexText({ filePath, mtime, config }: IndexerArgs): Promise<Chunk[]> {
+  const raw = await fs.readFile(filePath, "utf8");
+  const content = normalizeText(raw);
+  return chunkText(content, {
+    path: filePath,
+    type: "text",
+    size: config.index.chunkSize,
+    overlap: config.index.chunkOverlap,
+    mtime,
+  });
+}

--- a/src/indexers/types.ts
+++ b/src/indexers/types.ts
@@ -1,0 +1,10 @@
+import type { AppConfig, Chunk } from "../types.js";
+
+export interface IndexerArgs {
+  filePath: string;
+  mtime: number;
+  config: AppConfig;
+  tags?: string[];
+}
+
+export type IndexerFn = (args: IndexerArgs) => Promise<Chunk[]>;

--- a/src/indexers/word.ts
+++ b/src/indexers/word.ts
@@ -1,0 +1,16 @@
+import mammoth from "mammoth";
+import { chunkText } from "../pipeline/chunk.js";
+import { Chunk } from "../types.js";
+import { IndexerArgs } from "./types.js";
+
+export async function indexWord({ filePath, mtime, config }: IndexerArgs): Promise<Chunk[]> {
+  const result = await mammoth.extractRawText({ path: filePath });
+  const text = result.value ?? "";
+  return chunkText(text, {
+    path: filePath,
+    type: "word",
+    size: config.index.chunkSize,
+    overlap: config.index.chunkOverlap,
+    mtime,
+  });
+}

--- a/src/pipeline/chunk.ts
+++ b/src/pipeline/chunk.ts
@@ -1,0 +1,123 @@
+import { v5 as uuidv5 } from "uuid";
+import { Chunk, ChunkType } from "../types.js";
+
+const UUID_NAMESPACE = uuidv5("mcp-nn-chunk", uuidv5.URL);
+
+export interface ChunkOptions {
+  path: string;
+  type: ChunkType;
+  page?: number;
+  tags?: string[];
+  size: number;
+  overlap: number;
+  mtime: number;
+  partial?: boolean;
+}
+
+export function normalizeText(text: string): string {
+  return text
+    .normalize("NFKC")
+    .replace(/\r\n/g, "\n")
+    .replace(/[\t\v\f]+/g, " ")
+    .replace(/\u0000/g, "")
+    .replace(/\s+\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+function getSentences(text: string): { value: string; start: number; end: number }[] {
+  if (typeof (Intl as any).Segmenter === "function") {
+    const segmenter = new (Intl as any).Segmenter("en", { granularity: "sentence" });
+    const segments: { value: string; start: number; end: number }[] = [];
+    let offset = 0;
+    for (const segment of segmenter.segment(text)) {
+      const value = String(segment.segment);
+      const start = offset;
+      const end = offset + value.length;
+      segments.push({ value, start, end });
+      offset = end;
+    }
+    return segments;
+  }
+  const regex = /[^.!?\n]+[.!?\n]+|[^.!?\n]+$/g;
+  const segments: { value: string; start: number; end: number }[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(text))) {
+    segments.push({ value: match[0], start: match.index, end: match.index + match[0].length });
+  }
+  if (segments.length === 0) {
+    segments.push({ value: text, start: 0, end: text.length });
+  }
+  return segments;
+}
+
+export function chunkText(text: string, options: ChunkOptions): Chunk[] {
+  const normalized = normalizeText(text);
+  if (!normalized) return [];
+
+  const segments = getSentences(normalized);
+  const chunks: Chunk[] = [];
+  let buffer = "";
+  let bufferStart = 0;
+
+  const flush = (force = false) => {
+    if (!buffer) return;
+    if (!force && buffer.length < options.size && segments.length > 0) return;
+    const offsetStart = bufferStart;
+    const offsetEnd = offsetStart + buffer.length;
+    const idSource = `${options.path}|${options.page ?? ""}|${offsetStart}|${offsetEnd}`;
+    const id = uuidv5(idSource, UUID_NAMESPACE);
+    chunks.push({
+      id,
+      path: options.path,
+      type: options.type,
+      page: options.page,
+      offsetStart,
+      offsetEnd,
+      text: buffer,
+      tags: options.tags,
+      partial: options.partial,
+      mtime: options.mtime,
+    });
+    buffer = "";
+  };
+
+  for (const segment of segments) {
+    const candidate = buffer ? `${buffer}\n${segment.value.trim()}` : segment.value.trim();
+    if (candidate.length > options.size && buffer.length > 0) {
+      flush(true);
+      buffer = segment.value.trim();
+      bufferStart = segment.start;
+      continue;
+    }
+    if (!buffer) {
+      bufferStart = segment.start;
+      buffer = segment.value.trim();
+    } else if (candidate.length <= options.size) {
+      buffer = candidate;
+    } else {
+      flush(true);
+      buffer = segment.value.trim();
+      bufferStart = segment.start;
+    }
+  }
+
+  if (buffer) {
+    flush(true);
+  }
+
+  if (options.overlap > 0 && chunks.length > 1) {
+    for (let i = 1; i < chunks.length; i++) {
+      const prev = chunks[i - 1];
+      const curr = chunks[i];
+      if (curr.offsetStart !== undefined && curr.offsetStart - (prev.offsetEnd ?? 0) > options.overlap) {
+        const start = Math.max(curr.offsetStart - options.overlap, 0);
+        const textSlice = normalized.slice(start, curr.offsetStart);
+        curr.text = `${textSlice}\n${curr.text}`.trim();
+        curr.offsetStart = start;
+      }
+    }
+  }
+
+  return chunks;
+}

--- a/src/pipeline/detect-ocr.ts
+++ b/src/pipeline/detect-ocr.ts
@@ -1,0 +1,7 @@
+import { IndexConfig } from "../types.js";
+
+export function shouldRunOcr(pageText: string, config: IndexConfig): boolean {
+  if (!config.ocrEnabled) return false;
+  const trimmed = pageText.replace(/\s+/g, "");
+  return trimmed.length < config.ocrTriggerMinChars;
+}

--- a/src/pipeline/embed.ts
+++ b/src/pipeline/embed.ts
@@ -1,0 +1,52 @@
+import path from "path";
+import type { AppConfig } from "../types.js";
+
+type Extractor = (text: string, options: Record<string, unknown>) => Promise<{ data: Float32Array }>;
+
+let extractorPromise: Promise<Extractor> | undefined;
+
+function emitModelEvent(status: string) {
+  if (!process.stdout.writable) return;
+  process.stdout.write(`${JSON.stringify({ event: "model", status })}\n`);
+}
+
+async function loadExtractor(config: AppConfig): Promise<Extractor> {
+  if (!extractorPromise) {
+    extractorPromise = (async () => {
+      emitModelEvent("loading");
+      const transformers = await import("@xenova/transformers");
+      const pipelineFactory = (transformers as any).pipeline;
+      const options: Record<string, unknown> = {};
+      const modelCache = config.out.modelCacheDir;
+      if (modelCache) {
+        options.cache_dir = path.resolve(modelCache);
+      }
+      const pipe = await pipelineFactory("feature-extraction", config.index.model, options);
+      emitModelEvent("ready");
+      return async (text: string, opts: Record<string, unknown>) => {
+        const result = await pipe(text, opts);
+        return { data: result.data as Float32Array };
+      };
+    })();
+  }
+  return extractorPromise;
+}
+
+export class EmbeddingService {
+  constructor(private config: AppConfig) {}
+
+  async embed(text: string): Promise<Float32Array> {
+    const extractor = await loadExtractor(this.config);
+    const output = await extractor(text, { pooling: "mean", normalize: true });
+    return output.data;
+  }
+}
+
+let instance: EmbeddingService | undefined;
+
+export function getEmbeddingService(config: AppConfig): EmbeddingService {
+  if (!instance) {
+    instance = new EmbeddingService(config);
+  }
+  return instance;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,16 +1,172 @@
-import 'source-map-support/register';
+import "source-map-support/register";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import type { FSWatcher } from "chokidar";
+import type { ZodRawShape } from "zod";
+import { ensureInitialized } from "./store/store.js";
+import { searchLocal } from "./tools/searchLocal.js";
+import { getDoc } from "./tools/getDoc.js";
+import { reindexTool } from "./tools/reindex.js";
+import { statsTool } from "./tools/stats.js";
+import { createWatcher } from "./tools/watch.js";
+import { importChatGPT } from "./tools/importChatGPT.js";
+import { SearchLocalShape, GetDocShape, ReindexShape, WatchShape, ImportChatGPTShape } from "./store/schema.js";
 
-function log(level: string, msg: string, meta: Record<string, unknown> = {}) {
-  process.stdout.write(JSON.stringify({ level, msg, ...meta }) + '\n');
-}
+const toRawShape = (shape: ZodRawShape | Readonly<ZodRawShape>): ZodRawShape => ({ ...shape }) as ZodRawShape;
+
+const searchLocalSchema = toRawShape(SearchLocalShape);
+const getDocSchema = toRawShape(GetDocShape);
+const reindexSchema = toRawShape(ReindexShape);
+const watchSchema = toRawShape(WatchShape);
+const importChatGPTSchema = toRawShape(ImportChatGPTShape);
+
+const serverInfo = {
+  name: "mcp-nn",
+  version: "1.1.0",
+};
+
+const instructions = [
+  "NarcoNations.org offline research MCP server.",
+  "Use search_local for hybrid dense/BM25 search.",
+  "Use get_doc to fetch page-level content and citations.",
+  "Use reindex to refresh the local corpus when files change.",
+].join(" \n");
 
 async function main() {
-  log('info', 'mcp-nn skeleton ready', { mode: 'dev', transport: 'stdio' });
-  // Codex will replace this with the real MCP stdio server and tool registrations.
-  process.stdin.resume();
+  await ensureInitialized();
+  const mcpServer = new McpServer(serverInfo, { instructions });
+  const activeWatchers = new Set<FSWatcher>();
+  const registerTool = mcpServer.registerTool.bind(mcpServer) as (
+    name: string,
+    config: { description?: string; inputSchema?: ZodRawShape } & Record<string, unknown>,
+    handler: (args: unknown) => Promise<any>
+  ) => void;
+
+  registerTool("search_local", {
+    description: "Hybrid dense + keyword search across indexed research corpus.",
+    inputSchema: searchLocalSchema,
+  }, async args => {
+    const result = await searchLocal(args);
+    const lines = result.results.map(hit => `${hit.citation.filePath} (score ${hit.score.toFixed(3)})`);
+    return {
+      content: [
+        {
+          type: "text",
+          text: lines.length ? lines.join("\n") : "No results",
+        },
+      ],
+      structuredContent: result,
+    };
+  });
+
+  registerTool("get_doc", {
+    description: "Read indexed document text by path and optional page number.",
+    inputSchema: getDocSchema,
+  }, async args => {
+    const result = await getDoc(args);
+    return {
+      content: [
+        {
+          type: "text",
+          text: result.text.slice(0, 1200) || "",
+        },
+      ],
+      structuredContent: result,
+    };
+  });
+
+  registerTool("reindex", {
+    description: "Rebuild the local index for the configured roots or specific paths.",
+    inputSchema: reindexSchema,
+  }, async args => {
+    const summary = await reindexTool(args);
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Indexed: ${summary.indexed}, updated: ${summary.updated}, skipped: ${summary.skipped}`,
+        },
+      ],
+      structuredContent: summary,
+    };
+  });
+
+  mcpServer.registerTool("stats", {
+    description: "Return index statistics (files, chunks, averages).",
+  }, async () => {
+    const stats = await statsTool();
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Files: ${stats.files}, chunks: ${stats.chunks}`,
+        },
+      ],
+      structuredContent: stats,
+    };
+  });
+
+  registerTool("watch", {
+    description: "Watch configured directories for changes and reindex automatically.",
+    inputSchema: watchSchema,
+  }, async args => {
+    const watcher = await createWatcher(args, event => {
+      mcpServer.sendLoggingMessage({
+        level: "info",
+        logger: "mcp-nn-watch",
+        data: event,
+      }).catch(() => {});
+    });
+    activeWatchers.add(watcher);
+    return {
+      content: [
+        {
+          type: "text",
+          text: "Watching for changes",
+        },
+      ],
+      structuredContent: { status: "watching" },
+    };
+  });
+
+  registerTool("import_chatgpt_export", {
+    description: "Convert a ChatGPT export into Markdown and reindex the output directory.",
+    inputSchema: importChatGPTSchema,
+  }, async args => {
+    const summary = await importChatGPT(args);
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Converted ${summary.filesWritten} chats into ${summary.outDir}`,
+        },
+      ],
+      structuredContent: summary,
+    };
+  });
+
+  const transport = new StdioServerTransport();
+  await mcpServer.connect(transport);
+
+  const closeWatchers = async () => {
+    await Promise.allSettled(Array.from(activeWatchers, watcher => watcher.close()));
+    activeWatchers.clear();
+  };
+
+  process.on("SIGINT", async () => {
+    await closeWatchers();
+    await mcpServer.close();
+    process.exit(0);
+  });
+
+  process.on("SIGTERM", async () => {
+    await closeWatchers();
+    await mcpServer.close();
+    process.exit(0);
+  });
 }
 
-main().catch((err) => {
-  log('error', 'startup-failed', { err: String(err) });
+main().catch(err => {
+  console.error(JSON.stringify({ level: "error", msg: "startup_failed", error: err instanceof Error ? err.message : String(err) }));
   process.exit(1);
 });

--- a/src/store/keyword.ts
+++ b/src/store/keyword.ts
@@ -1,0 +1,97 @@
+import { promises as fs } from "fs";
+import path from "path";
+import FlexSearch from "flexsearch";
+import type { Chunk } from "../types.js";
+import { ensureDir } from "../utils/fs-guard.js";
+
+interface KeywordDoc {
+  id: string;
+  text: string;
+  tags?: string[];
+  type: string;
+}
+
+export class KeywordIndex {
+  private index: any;
+  private docs = new Map<string, KeywordDoc>();
+
+  constructor(private dir: string) {
+    this.index = new (FlexSearch as any).Document({
+      id: "id",
+      document: {
+        id: "id",
+        index: ["text", "tags"],
+        store: ["text", "tags", "type"],
+      },
+      tokenize: "forward",
+    });
+  }
+
+  private filePath() {
+    return path.join(this.dir, "keyword-docs.json");
+  }
+
+  async load(): Promise<void> {
+    await ensureDir(this.dir);
+    try {
+      const raw = await fs.readFile(this.filePath(), "utf8");
+      const docs: KeywordDoc[] = JSON.parse(raw);
+      docs.forEach(doc => this.addDoc(doc));
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw err;
+      }
+    }
+  }
+
+  private addDoc(doc: KeywordDoc) {
+    this.docs.set(doc.id, doc);
+    this.index.add({
+      id: doc.id,
+      text: doc.text,
+      tags: (doc.tags ?? []).join(" "),
+      type: doc.type,
+    });
+  }
+
+  add(chunk: Chunk) {
+    const doc: KeywordDoc = {
+      id: chunk.id,
+      text: chunk.text,
+      tags: chunk.tags,
+      type: chunk.type,
+    };
+    this.addDoc(doc);
+  }
+
+  remove(chunkId: string) {
+    this.docs.delete(chunkId);
+    this.index.remove(chunkId);
+  }
+
+  search(query: string, limit: number): Array<{ chunkId: string; score: number }> {
+    const enriched = this.index.search(query, { enrich: true, limit });
+    const seen = new Set<string>();
+    const results: Array<{ chunkId: string; score: number }> = [];
+    for (const field of enriched as Array<{ field: string; result: Array<{ id: string; score: number }> }>) {
+      for (const item of field.result) {
+        if (!seen.has(item.id)) {
+          seen.add(item.id);
+          results.push({ chunkId: item.id, score: item.score ?? 0 });
+          if (results.length >= limit) return results;
+        }
+      }
+    }
+    return results;
+  }
+
+  count(): number {
+    return this.docs.size;
+  }
+
+  async persist(): Promise<void> {
+    await ensureDir(this.dir);
+    const docs = Array.from(this.docs.values());
+    await fs.writeFile(this.filePath(), JSON.stringify(docs, null, 2), "utf8");
+  }
+}

--- a/src/store/schema.ts
+++ b/src/store/schema.ts
@@ -1,0 +1,53 @@
+import type { ZodRawShape } from "zod";
+import { z } from "zod";
+
+const searchLocalShape = {
+  query: z.string().min(1),
+  k: z.number().int().min(1).max(50).default(8),
+  alpha: z.number().min(0).max(1).default(0.65),
+  filters: z
+    .object({
+      type: z.array(z.enum(["pdf", "markdown", "text", "word", "pages"])).optional(),
+    })
+    .partial()
+    .optional(),
+};
+
+const getDocShape = {
+  path: z.string().min(1),
+  page: z.number().int().min(1).optional(),
+};
+
+const reindexShape = {
+  paths: z.array(z.string().min(1)).optional(),
+};
+
+const watchShape = {
+  paths: z.array(z.string().min(1)).optional(),
+};
+
+const importChatGPTShape = {
+  exportPath: z.string().min(1),
+  outDir: z.string().min(1).default("./docs/chatgpt-export-md"),
+};
+
+export const SearchLocalInput = z.object(searchLocalShape);
+export const GetDocInput = z.object(getDocShape);
+export const ReindexInput = z.object(reindexShape);
+export const WatchInput = z.object(watchShape);
+export const ImportChatGPTInput = z.object(importChatGPTShape);
+
+export const SearchLocalShape: ZodRawShape = searchLocalShape;
+export const GetDocShape: ZodRawShape = getDocShape;
+export const ReindexShape: ZodRawShape = reindexShape;
+export const WatchShape: ZodRawShape = watchShape;
+export const ImportChatGPTShape: ZodRawShape = importChatGPTShape;
+
+export const StatsOutput = z.object({
+  files: z.number(),
+  chunks: z.number(),
+  byType: z.record(z.string(), z.number()),
+  avgChunkLen: z.number(),
+  embeddingsCached: z.number(),
+  lastIndexedAt: z.number().optional(),
+});

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,0 +1,289 @@
+import { promises as fs } from "fs";
+import type { Stats } from "node:fs";
+import path from "path";
+import { loadConfig } from "../config.js";
+import { runIndexer } from "../indexers/index.js";
+import type { AppConfig, Chunk, HybridSearchOptions, Manifest, ManifestEntry, ReindexSummary, SearchHit } from "../types.js";
+import { buildCitation } from "../utils/cite.js";
+import { ensureDir, assertWithinRoots, collectFiles, pathStats } from "../utils/fs-guard.js";
+import { createLogger } from "../utils/logger.js";
+import { now } from "../utils/time.js";
+import { getEmbeddingService } from "../pipeline/embed.js";
+import { FlatVectorIndex } from "./vector-flat.js";
+import { KeywordIndex } from "./keyword.js";
+
+const logger = createLogger("store");
+
+const EMPTY_MANIFEST: Manifest = {
+  files: {},
+  chunks: {},
+  stats: {
+    files: 0,
+    chunks: 0,
+    byType: {
+      pdf: 0,
+      markdown: 0,
+      text: 0,
+      word: 0,
+      pages: 0,
+    },
+    avgChunkLen: 0,
+    embeddingsCached: 0,
+  },
+};
+
+class Store {
+  private manifest: Manifest = EMPTY_MANIFEST;
+  private config!: AppConfig;
+  private dataDir!: string;
+  private manifestPath!: string;
+  private vectorIndex!: FlatVectorIndex;
+  private keywordIndex!: KeywordIndex;
+  private initialized = false;
+
+  async init(): Promise<void> {
+    if (this.initialized) return;
+    this.config = await loadConfig();
+    this.dataDir = this.config.out.dataDir;
+    this.manifestPath = path.join(this.dataDir, "manifest.json");
+    await ensureDir(this.dataDir);
+
+    try {
+      const raw = await fs.readFile(this.manifestPath, "utf8");
+      this.manifest = JSON.parse(raw) as Manifest;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+        logger.warn("manifest_load_failed", { error: String(err) });
+      }
+      this.manifest = JSON.parse(JSON.stringify(EMPTY_MANIFEST));
+    }
+
+    this.vectorIndex = new FlatVectorIndex(this.dataDir);
+    await this.vectorIndex.load();
+
+    this.keywordIndex = new KeywordIndex(this.dataDir);
+    await this.keywordIndex.load();
+
+    // Rehydrate keyword index from manifest if needed
+    if (this.keywordIndex.count() === 0) {
+      Object.values(this.manifest.chunks).forEach(chunk => this.keywordIndex.add(chunk));
+    }
+
+    this.initialized = true;
+  }
+
+  private async persist(): Promise<void> {
+    await fs.writeFile(this.manifestPath, JSON.stringify(this.manifest, null, 2), "utf8");
+    await this.vectorIndex.persist();
+    await this.keywordIndex.persist();
+  }
+
+  private updateStats(): void {
+    const chunks = Object.values(this.manifest.chunks);
+    const byType = { pdf: 0, markdown: 0, text: 0, word: 0, pages: 0 } as Manifest["stats"]["byType"];
+    let totalLength = 0;
+    chunks.forEach(chunk => {
+      byType[chunk.type] = (byType[chunk.type] ?? 0) + 1;
+      totalLength += chunk.text.length;
+    });
+    this.manifest.stats = {
+      files: Object.keys(this.manifest.files).length,
+      chunks: chunks.length,
+      byType,
+      avgChunkLen: chunks.length ? totalLength / chunks.length : 0,
+      embeddingsCached: this.vectorIndex.size(),
+      lastIndexedAt: now(),
+    };
+  }
+
+  private async indexFile(filePath: string, stats: Stats): Promise<Chunk[]> {
+    const tags: string[] | undefined = undefined;
+    const chunks = await runIndexer({
+      filePath,
+      mtime: stats.mtimeMs,
+      config: this.config,
+      tags,
+    });
+    return chunks;
+  }
+
+  private async upsertFile(filePath: string, stats: Stats): Promise<void> {
+    const existing = this.manifest.files[filePath];
+    if (existing) {
+      this.vectorIndex.removeVectors(existing.chunkIds);
+      existing.chunkIds.forEach(id => {
+        delete this.manifest.chunks[id];
+        this.keywordIndex.remove(id);
+      });
+    }
+
+    const chunks = await this.indexFile(filePath, stats);
+    const chunkIds = chunks.map(chunk => chunk.id);
+
+    const embedder = getEmbeddingService(this.config);
+    for (const chunk of chunks) {
+      this.manifest.chunks[chunk.id] = chunk;
+      this.keywordIndex.add(chunk);
+      const vector = await embedder.embed(chunk.text);
+      this.vectorIndex.setVector(chunk.id, vector);
+    }
+
+    const entry: ManifestEntry = {
+      path: filePath,
+      type: chunks[0]?.type ?? "text",
+      mtime: stats.mtimeMs,
+      size: stats.size,
+      chunkIds,
+      partial: chunks.some(chunk => chunk.partial),
+    };
+    this.manifest.files[filePath] = entry;
+  }
+
+  private async removeFile(filePath: string): Promise<void> {
+    const existing = this.manifest.files[filePath];
+    if (!existing) return;
+    this.vectorIndex.removeVectors(existing.chunkIds);
+    existing.chunkIds.forEach(id => {
+      delete this.manifest.chunks[id];
+      this.keywordIndex.remove(id);
+    });
+    delete this.manifest.files[filePath];
+  }
+
+  async reindex(paths?: string[]): Promise<ReindexSummary> {
+    await this.init();
+    const targets = await collectFiles(paths ?? [], this.config.roots);
+    let indexed = 0;
+    let updated = 0;
+    let skipped = 0;
+
+    for (const file of targets) {
+      const resolved = assertWithinRoots(file, this.config.roots.roots);
+      const stats = await pathStats(resolved);
+      if (!stats) continue;
+      if (this.config.index.maxFileSizeMB && stats.size > this.config.index.maxFileSizeMB * 1024 * 1024) {
+        logger.warn("file_too_large", { file: resolved, size: stats.size });
+        skipped++;
+        continue;
+      }
+      const existing = this.manifest.files[resolved];
+      if (existing && existing.mtime === stats.mtimeMs && existing.size === stats.size) {
+        skipped++;
+        continue;
+      }
+      await this.upsertFile(resolved, stats);
+      if (existing) updated++;
+      else indexed++;
+    }
+
+    this.updateStats();
+    await this.persist();
+
+    return { indexed, updated, skipped };
+  }
+
+  async removeMissingFiles(): Promise<void> {
+    await this.init();
+    const files = Object.keys(this.manifest.files);
+    for (const file of files) {
+      const stats = await pathStats(file);
+      if (!stats) {
+        await this.removeFile(file);
+      }
+    }
+    this.updateStats();
+    await this.persist();
+  }
+
+  async hybridSearch(options: HybridSearchOptions): Promise<SearchHit[]> {
+    await this.init();
+    const embedder = getEmbeddingService(this.config);
+    const queryVector = await embedder.embed(options.query);
+    const denseHits = this.vectorIndex.search(queryVector, Math.max(options.k * 4, 64));
+    const keywordHits = this.keywordIndex.search(options.query, Math.max(options.k * 4, 64));
+
+    const scores = new Map<string, { dense: number; keyword: number }>();
+    for (const hit of denseHits) {
+      scores.set(hit.chunkId, { dense: hit.score, keyword: 0 });
+    }
+    for (const hit of keywordHits) {
+      const existing = scores.get(hit.chunkId) ?? { dense: 0, keyword: 0 };
+      existing.keyword = Math.max(existing.keyword, hit.score);
+      scores.set(hit.chunkId, existing);
+    }
+
+    const chunks = this.manifest.chunks;
+    const filtered = Array.from(scores.entries())
+      .map(([chunkId, score]) => {
+        const chunk = chunks[chunkId];
+        if (!chunk) return undefined;
+        if (options.filters?.type && !options.filters.type.includes(chunk.type)) return undefined;
+        const combined = options.alpha * score.dense + (1 - options.alpha) * score.keyword;
+        return { chunk, score: combined };
+      })
+      .filter((value): value is { chunk: Chunk; score: number } => Boolean(value));
+
+    filtered.sort((a, b) => b.score - a.score);
+    return filtered.slice(0, options.k).map(({ chunk, score }) => ({
+      chunkId: chunk.id,
+      score,
+      text: chunk.text.slice(0, 600),
+      citation: buildCitation(chunk),
+    }));
+  }
+
+  async getDocument(pathInput: string, page?: number): Promise<{ path: string; page?: number; text: string }> {
+    await this.init();
+    const pathResolved = assertWithinRoots(pathInput, this.config.roots.roots);
+    const chunks = Object.values(this.manifest.chunks).filter(chunk => chunk.path === pathResolved);
+    if (chunks.length === 0) {
+      throw new Error(`File ${pathResolved} is not indexed.`);
+    }
+    let text = "";
+    if (page) {
+      text = chunks
+        .filter(chunk => chunk.page === page)
+        .map(chunk => chunk.text)
+        .join("\n\n");
+    } else {
+      text = chunks
+        .sort((a, b) => (a.offsetStart ?? 0) - (b.offsetStart ?? 0))
+        .map(chunk => chunk.text)
+        .join("\n\n");
+    }
+    return { path: pathResolved, page, text };
+  }
+
+  getStats(): Manifest["stats"] {
+    return this.manifest.stats;
+  }
+}
+
+let storeInstance: Store | undefined;
+
+function getStoreInstance(): Store {
+  if (!storeInstance) {
+    storeInstance = new Store();
+  }
+  return storeInstance;
+}
+
+export async function reindexPaths(paths?: string[]): Promise<ReindexSummary> {
+  return getStoreInstance().reindex(paths);
+}
+
+export async function searchHybrid(options: HybridSearchOptions): Promise<SearchHit[]> {
+  return getStoreInstance().hybridSearch(options);
+}
+
+export async function getDocument(path: string, page?: number) {
+  return getStoreInstance().getDocument(path, page);
+}
+
+export async function getStats() {
+  return getStoreInstance().getStats();
+}
+
+export async function ensureInitialized() {
+  await getStoreInstance().init();
+}

--- a/src/store/vector-flat.ts
+++ b/src/store/vector-flat.ts
@@ -1,0 +1,111 @@
+import { promises as fs } from "fs";
+import path from "path";
+import { ensureDir } from "../utils/fs-guard.js";
+
+interface ManifestEntry {
+  offset: number;
+  length: number;
+}
+
+interface VectorManifest {
+  dimension: number;
+  vectors: Record<string, ManifestEntry>;
+}
+
+export class FlatVectorIndex {
+  private vectors = new Map<string, Float32Array>();
+  private dimension: number | undefined;
+
+  constructor(private dir: string) {}
+
+  private manifestPath() {
+    return path.join(this.dir, "vectors.json");
+  }
+
+  private dataPath() {
+    return path.join(this.dir, "vectors.bin");
+  }
+
+  async load(): Promise<void> {
+    await ensureDir(this.dir);
+    try {
+      const manifestRaw = await fs.readFile(this.manifestPath(), "utf8");
+      const manifest = JSON.parse(manifestRaw) as VectorManifest;
+      const data = await fs.readFile(this.dataPath());
+      const floatView = new Float32Array(data.buffer, data.byteOffset, data.byteLength / 4);
+      this.dimension = manifest.dimension;
+      Object.entries(manifest.vectors).forEach(([chunkId, info]) => {
+        const slice = floatView.slice(info.offset, info.offset + info.length);
+        this.vectors.set(chunkId, Float32Array.from(slice));
+      });
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw err;
+      }
+    }
+  }
+
+  setVector(chunkId: string, vector: Float32Array) {
+    if (!this.dimension) {
+      this.dimension = vector.length;
+    }
+    if (vector.length !== this.dimension) {
+      throw new Error(`Vector dimension mismatch: expected ${this.dimension}, received ${vector.length}`);
+    }
+    this.vectors.set(chunkId, Float32Array.from(vector));
+  }
+
+  removeVectors(chunkIds: string[]) {
+    chunkIds.forEach(id => this.vectors.delete(id));
+  }
+
+  search(query: Float32Array, k: number): Array<{ chunkId: string; score: number }> {
+    const results: Array<{ chunkId: string; score: number }> = [];
+    for (const [chunkId, vector] of this.vectors.entries()) {
+      let dot = 0;
+      for (let i = 0; i < vector.length; i++) {
+        dot += vector[i] * query[i];
+      }
+      if (results.length < k) {
+        results.push({ chunkId, score: dot });
+        results.sort((a, b) => b.score - a.score);
+      } else if (dot > results[results.length - 1].score) {
+        results[results.length - 1] = { chunkId, score: dot };
+        results.sort((a, b) => b.score - a.score);
+      }
+    }
+    return results.slice(0, k);
+  }
+
+  size(): number {
+    return this.vectors.size;
+  }
+
+  async persist(): Promise<void> {
+    await ensureDir(this.dir);
+    if (!this.dimension) {
+      await fs.writeFile(this.manifestPath(), JSON.stringify({ dimension: 0, vectors: {} }, null, 2));
+      await fs.writeFile(this.dataPath(), Buffer.alloc(0));
+      return;
+    }
+    const entries = Array.from(this.vectors.entries());
+    const floatsPerVector = this.dimension;
+    const totalFloats = floatsPerVector * entries.length;
+    const buffer = Buffer.alloc(totalFloats * 4);
+    const view = new Float32Array(buffer.buffer, buffer.byteOffset, totalFloats);
+
+    const manifest: VectorManifest = {
+      dimension: this.dimension,
+      vectors: {},
+    };
+
+    entries.forEach(([chunkId, vector], idx) => {
+      const offset = idx * floatsPerVector;
+      view.set(vector, offset);
+      manifest.vectors[chunkId] = { offset, length: floatsPerVector };
+    });
+
+    await fs.writeFile(this.manifestPath(), JSON.stringify(manifest, null, 2));
+    await fs.writeFile(this.dataPath(), buffer);
+  }
+}

--- a/src/store/vector-sqlitevss.ts
+++ b/src/store/vector-sqlitevss.ts
@@ -1,0 +1,24 @@
+import { createRequire } from "module";
+import { createLogger } from "../utils/logger.js";
+
+const logger = createLogger("vector-sqlite");
+const require = createRequire(import.meta.url);
+
+export interface SQLiteVectorIndex {
+  load(): Promise<void>;
+  setVector(chunkId: string, vector: Float32Array): void;
+  removeVectors(chunkIds: string[]): void;
+  search(query: Float32Array, k: number): Promise<Array<{ chunkId: string; score: number }>>;
+  size(): number;
+  persist(): Promise<void>;
+}
+
+export async function tryCreateSQLiteVSS(_dir: string): Promise<SQLiteVectorIndex | undefined> {
+  try {
+    require("sqlite3");
+    logger.info("sqlite_vss_not_configured", { message: "sqlite-vss support is not implemented in this build" });
+  } catch (err) {
+    logger.info("sqlite_vss_unavailable", { reason: String(err) });
+  }
+  return undefined;
+}

--- a/src/tools/getDoc.ts
+++ b/src/tools/getDoc.ts
@@ -1,0 +1,10 @@
+import type { z } from "zod";
+import { GetDocInput } from "../store/schema.js";
+import { getDocument } from "../store/store.js";
+
+type GetDocArgs = z.infer<typeof GetDocInput>;
+
+export async function getDoc(input: unknown) {
+  const parsed: GetDocArgs = GetDocInput.parse(input);
+  return getDocument(parsed.path, parsed.page);
+}

--- a/src/tools/importChatGPT.ts
+++ b/src/tools/importChatGPT.ts
@@ -1,0 +1,62 @@
+import { spawn } from "child_process";
+import path from "path";
+import { promises as fs } from "fs";
+import { ImportChatGPTInput } from "../store/schema.js";
+import { reindexPaths } from "../store/store.js";
+function withinAllowed(outDir: string): boolean {
+  const abs = path.resolve(outDir);
+  const rel = path.relative(process.cwd(), abs);
+  if (rel.startsWith("..") || path.isAbsolute(rel) && !abs.startsWith(process.cwd())) return false;
+  const top = rel.split(path.sep)[0];
+  return ["docs", "public", "fixtures", ".mcp-nn"].includes(top);
+}
+
+async function runConverter(exportPath: string, outDir: string): Promise<number> {
+  const tsNode = path.join(process.cwd(), "node_modules", ".bin", "ts-node");
+  const script = path.join(process.cwd(), "scripts", "chatgpt-export-to-md.ts");
+  await fs.access(script);
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(tsNode, [script, "--", exportPath, outDir], { stdio: ["ignore", "pipe", "pipe"] });
+    let filesWritten = 0;
+    child.stdout.on("data", data => {
+      const line = String(data).trim();
+      try {
+        const evt = JSON.parse(line);
+        if (evt?.meta?.filesWritten) {
+          filesWritten = evt.meta.filesWritten;
+        }
+      } catch {
+        // ignore non-JSON output
+      }
+    });
+    child.stderr.on("data", data => process.stderr.write(data));
+    child.on("error", reject);
+    child.on("close", code => {
+      if (code !== 0) {
+        reject(new Error(`chatgpt-export-to-md exited with code ${code}`));
+      } else {
+        resolve(filesWritten);
+      }
+    });
+  });
+}
+
+export async function importChatGPT(input: unknown) {
+  const parsed = ImportChatGPTInput.parse(input ?? {});
+  const outDirAbs = path.resolve(parsed.outDir);
+  if (!withinAllowed(outDirAbs)) {
+    throw new Error(`outDir must be inside docs/, public/, fixtures/, or .mcp-nn/: ${parsed.outDir}`);
+  }
+
+  await fs.mkdir(outDirAbs, { recursive: true });
+
+  const filesWritten = await runConverter(parsed.exportPath, outDirAbs);
+  const summary = await reindexPaths([outDirAbs]);
+
+  return {
+    filesWritten,
+    outDir: outDirAbs,
+    indexed: summary,
+  };
+}

--- a/src/tools/reindex.ts
+++ b/src/tools/reindex.ts
@@ -1,0 +1,10 @@
+import type { z } from "zod";
+import { ReindexInput } from "../store/schema.js";
+import { reindexPaths } from "../store/store.js";
+
+type ReindexArgs = z.infer<typeof ReindexInput>;
+
+export async function reindexTool(input: unknown) {
+  const parsed: ReindexArgs = ReindexInput.parse(input ?? {});
+  return reindexPaths(parsed.paths);
+}

--- a/src/tools/searchLocal.ts
+++ b/src/tools/searchLocal.ts
@@ -1,0 +1,16 @@
+import type { z } from "zod";
+import { SearchLocalInput } from "../store/schema.js";
+import { searchHybrid } from "../store/store.js";
+
+type SearchArgs = z.infer<typeof SearchLocalInput>;
+
+export async function searchLocal(input: unknown) {
+  const parsed: SearchArgs = SearchLocalInput.parse(input);
+  const results = await searchHybrid({
+    query: parsed.query,
+    k: parsed.k ?? 8,
+    alpha: parsed.alpha ?? 0.65,
+    filters: parsed.filters,
+  });
+  return { query: parsed.query, results };
+}

--- a/src/tools/stats.ts
+++ b/src/tools/stats.ts
@@ -1,0 +1,5 @@
+import { getStats } from "../store/store.js";
+
+export async function statsTool() {
+  return getStats();
+}

--- a/src/tools/watch.ts
+++ b/src/tools/watch.ts
@@ -1,0 +1,51 @@
+import chokidar from "chokidar";
+import path from "path";
+import { WatchInput } from "../store/schema.js";
+import { reindexPaths } from "../store/store.js";
+import { loadConfig } from "../config.js";
+import { createLogger } from "../utils/logger.js";
+
+const logger = createLogger("watch");
+
+export type WatchEvent = {
+  event: "add" | "change" | "unlink";
+  path: string;
+};
+
+export async function createWatcher(input: unknown, onEvent?: (event: WatchEvent) => void) {
+  const parsed = WatchInput.parse(input ?? {});
+  const config = await loadConfig();
+  const targets = parsed.paths && parsed.paths.length ? parsed.paths : config.roots.roots;
+  const watcher = chokidar.watch(targets, {
+    ignored: config.roots.exclude,
+    ignoreInitial: true,
+    awaitWriteFinish: {
+      stabilityThreshold: 250,
+      pollInterval: 100,
+    },
+  });
+
+  watcher.on("all", async (eventName, filePath) => {
+    if (!filePath) return;
+    if (!config.roots.include.includes(path.extname(filePath).toLowerCase())) return;
+    const evt: WatchEvent = {
+      event: eventName === "add" ? "add" : eventName === "unlink" ? "unlink" : "change",
+      path: filePath,
+    };
+    onEvent?.(evt);
+    try {
+      await reindexPaths([filePath]);
+    } catch (err) {
+      logger.error("watch_reindex_failed", { file: filePath, error: String(err) });
+    }
+  });
+
+  return watcher;
+}
+
+export async function watchTool(input: unknown) {
+  await createWatcher(input, event => {
+    logger.info("watch_event", event);
+  });
+  return { status: "watching" };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,101 @@
+import type { z } from "zod";
+
+export type ChunkType = "pdf" | "markdown" | "text" | "word" | "pages";
+
+export interface Chunk {
+  id: string;
+  path: string;
+  type: ChunkType;
+  page?: number;
+  offsetStart?: number;
+  offsetEnd?: number;
+  text: string;
+  tokens?: number;
+  tags?: string[];
+  partial?: boolean;
+  mtime: number;
+}
+
+export interface Citation {
+  filePath: string;
+  page?: number;
+  startChar?: number;
+  endChar?: number;
+  snippet: string;
+}
+
+export interface SearchHit {
+  chunkId: string;
+  score: number;
+  text: string;
+  citation: Citation;
+}
+
+export interface HybridSearchOptions {
+  query: string;
+  k: number;
+  alpha: number;
+  filters?: {
+    type?: ChunkType[];
+  };
+}
+
+export interface RootsConfig {
+  roots: string[];
+  include: string[];
+  exclude: string[];
+}
+
+export interface IndexConfig {
+  chunkSize: number;
+  chunkOverlap: number;
+  ocrEnabled: boolean;
+  ocrTriggerMinChars: number;
+  useSQLiteVSS: boolean;
+  model: string;
+  maxFileSizeMB?: number;
+  concurrency?: number;
+  languages?: string[];
+}
+
+export interface OutConfig {
+  dataDir: string;
+  modelCacheDir?: string;
+}
+
+export interface AppConfig {
+  roots: RootsConfig;
+  index: IndexConfig;
+  out: OutConfig;
+}
+
+export interface ManifestEntry {
+  path: string;
+  type: ChunkType;
+  mtime: number;
+  size: number;
+  chunkIds: string[];
+  partial?: boolean;
+  tags?: string[];
+}
+
+export interface Manifest {
+  files: Record<string, ManifestEntry>;
+  chunks: Record<string, Chunk>;
+  stats: {
+    files: number;
+    chunks: number;
+    byType: Record<ChunkType, number>;
+    avgChunkLen: number;
+    embeddingsCached: number;
+    lastIndexedAt?: number;
+  };
+}
+
+export interface ReindexSummary {
+  indexed: number;
+  updated: number;
+  skipped: number;
+}
+
+export type ZodSchema<T> = z.ZodType<T>;

--- a/src/utils/cite.ts
+++ b/src/utils/cite.ts
@@ -1,0 +1,36 @@
+import { Citation, Chunk } from "../types.js";
+
+const SNIPPET_MIN = 160;
+const SNIPPET_MAX = 300;
+
+function clampSnippet(text: string, start: number, end: number): string {
+  const length = text.length;
+  const span = end - start;
+  let snippetStart = Math.max(0, start - Math.max(0, (SNIPPET_MAX - span) / 2));
+  let snippetEnd = Math.min(length, end + Math.max(0, (SNIPPET_MAX - span) / 2));
+
+  if (snippetEnd - snippetStart < SNIPPET_MIN) {
+    const padding = Math.ceil((SNIPPET_MIN - (snippetEnd - snippetStart)) / 2);
+    snippetStart = Math.max(0, snippetStart - padding);
+    snippetEnd = Math.min(length, snippetEnd + padding);
+  }
+
+  let snippet = text.slice(snippetStart, snippetEnd).trim();
+  if (snippetStart > 0) snippet = `…${snippet}`;
+  if (snippetEnd < length) snippet = `${snippet}…`;
+  return snippet.replace(/\s+/g, " ");
+}
+
+export function buildCitation(chunk: Chunk, start?: number, end?: number): Citation {
+  const startChar = start ?? chunk.offsetStart ?? 0;
+  const endChar = end ?? chunk.offsetEnd ?? Math.min(chunk.text.length, startChar + SNIPPET_MIN);
+  const snippet = clampSnippet(chunk.text, startChar, endChar);
+
+  return {
+    filePath: chunk.path,
+    page: chunk.page,
+    startChar,
+    endChar,
+    snippet,
+  };
+}

--- a/src/utils/fs-guard.ts
+++ b/src/utils/fs-guard.ts
@@ -1,0 +1,78 @@
+import { promises as fs } from "fs";
+import path from "path";
+import fastGlob from "fast-glob";
+import { RootsConfig } from "../types.js";
+
+export async function ensureDir(dir: string): Promise<void> {
+  await fs.mkdir(dir, { recursive: true });
+}
+
+export async function pathStats(target: string) {
+  try {
+    return await fs.stat(target);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    throw err;
+  }
+}
+
+export function normalize(p: string): string {
+  return path.normalize(p).replace(/\\/g, "/");
+}
+
+export function withinRoots(targetPath: string, roots: string[]): boolean {
+  const target = path.resolve(targetPath);
+  return roots.some(root => {
+    const absRoot = path.resolve(root);
+    const rel = path.relative(absRoot, target);
+    return rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel));
+  });
+}
+
+export function assertWithinRoots(targetPath: string, roots: string[]): string {
+  const target = path.resolve(targetPath);
+  const ok = roots.some(root => {
+    const absRoot = path.resolve(root);
+    const rel = path.relative(absRoot, target);
+    return rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel));
+  });
+  if (!ok) {
+    throw new Error(`Path ${targetPath} is outside configured roots`);
+  }
+  return target;
+}
+
+export function isAllowedExtension(filePath: string, config: RootsConfig): boolean {
+  const ext = path.extname(filePath).toLowerCase();
+  return config.include.includes(ext);
+}
+
+export async function collectFiles(paths: string[], config: RootsConfig): Promise<string[]> {
+  const inputs = paths.length ? paths : config.roots;
+  const results: string[] = [];
+  for (const input of inputs) {
+    const resolved = path.resolve(input);
+    const stats = await pathStats(resolved);
+    if (!stats) continue;
+    if (stats.isDirectory()) {
+      const pattern = path.join(resolved, "**/*");
+      const entries = await fastGlob(pattern, {
+        dot: false,
+        onlyFiles: true,
+        caseSensitiveMatch: false,
+        followSymbolicLinks: false,
+        ignore: config.exclude,
+      });
+      for (const entry of entries) {
+        if (isAllowedExtension(entry, config)) {
+          results.push(path.resolve(entry));
+        }
+      }
+    } else if (stats.isFile()) {
+      if (isAllowedExtension(resolved, config)) {
+        results.push(resolved);
+      }
+    }
+  }
+  return Array.from(new Set(results));
+}

--- a/src/utils/hash.ts
+++ b/src/utils/hash.ts
@@ -1,0 +1,11 @@
+import crypto from "crypto";
+
+export function hashContent(...parts: (string | number | undefined | null)[]): string {
+  const hash = crypto.createHash("sha256");
+  for (const part of parts) {
+    if (part === undefined || part === null) continue;
+    hash.update(String(part));
+    hash.update("\u0000");
+  }
+  return hash.digest("hex");
+}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,39 @@
+type Level = "debug" | "info" | "warn" | "error";
+const DEBUG_ENABLED = Boolean(process.env.DEBUG) || process.env.NODE_ENV === "development";
+
+interface LogEntry {
+  level: Level;
+  msg: string;
+  scope?: string;
+  meta?: Record<string, unknown>;
+}
+
+function emit(entry: LogEntry) {
+  if (!process.stdout.writable) return;
+  const payload: Record<string, unknown> = {
+    level: entry.level,
+    msg: entry.msg,
+    ts: new Date().toISOString(),
+  };
+  if (entry.scope) payload.scope = entry.scope;
+  if (entry.meta && Object.keys(entry.meta).length > 0) {
+    payload.meta = entry.meta;
+  }
+  process.stdout.write(`${JSON.stringify(payload)}\n`);
+}
+
+export function createLogger(scope: string) {
+  function log(level: Level, msg: string, meta?: Record<string, unknown>) {
+    if (level === "debug" && !DEBUG_ENABLED) return;
+    emit({ level, msg, scope, meta });
+  }
+
+  return {
+    debug: (msg: string, meta?: Record<string, unknown>) => log("debug", msg, meta),
+    info: (msg: string, meta?: Record<string, unknown>) => log("info", msg, meta),
+    warn: (msg: string, meta?: Record<string, unknown>) => log("warn", msg, meta),
+    error: (msg: string, meta?: Record<string, unknown>) => log("error", msg, meta),
+  };
+}
+
+export type Logger = ReturnType<typeof createLogger>;

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,0 +1,7 @@
+export function now(): number {
+  return Date.now();
+}
+
+export function durationMs(start: number): number {
+  return now() - start;
+}

--- a/tests/chatgpt.convert.test.ts
+++ b/tests/chatgpt.convert.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import { promises as fs } from "fs";
+import path from "path";
+import os from "os";
+import { convertChatGPTExport } from "../scripts/chatgpt-export-to-md.ts";
+
+describe("chatgpt export converter", () => {
+  it("writes markdown files with metadata", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "chatgpt-md-"));
+    const exportPath = path.join(process.cwd(), "fixtures", "chatgpt-export-sample");
+    const result = await convertChatGPTExport(exportPath, tempDir);
+    expect(result.filesWritten).toBeGreaterThan(0);
+    const files = await fs.readdir(tempDir);
+    const content = await fs.readFile(path.join(tempDir, files[0]), "utf8");
+    expect(content).toContain("Sample Chat");
+    expect(content).toContain('source: "chatgpt-export"');
+  });
+});

--- a/tests/chunk.test.ts
+++ b/tests/chunk.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { chunkText } from "../src/pipeline/chunk.js";
+
+const sampleText = Array.from({ length: 20 })
+  .map((_, idx) => `Paragraph ${idx + 1}: Antwerp port security operations and cocaine interdiction details.`)
+  .join("\n\n");
+
+describe("chunkText", () => {
+  it("splits large text into stable chunk ids with overlap", () => {
+    const chunksA = chunkText(sampleText, {
+      path: "/docs/sample.txt",
+      type: "text",
+      size: 200,
+      overlap: 40,
+      mtime: Date.now(),
+    });
+    const chunksB = chunkText(sampleText, {
+      path: "/docs/sample.txt",
+      type: "text",
+      size: 200,
+      overlap: 40,
+      mtime: Date.now(),
+    });
+
+    expect(chunksA.length).toBeGreaterThan(1);
+    expect(chunksA[0].offsetStart).toBe(0);
+    expect(chunksA[0].text.length).toBeLessThanOrEqual(200 + 40);
+    expect(chunksA.map(chunk => chunk.id)).toEqual(chunksB.map(chunk => chunk.id));
+  });
+});

--- a/tests/indexers.pages.test.ts
+++ b/tests/indexers.pages.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import os from "os";
+import path from "path";
+import { promises as fs } from "fs";
+import AdmZip from "adm-zip";
+import { indexPages } from "../src/indexers/pages.js";
+import type { AppConfig } from "../src/types.js";
+
+const baseConfig: AppConfig = {
+  roots: {
+    roots: [process.cwd()],
+    include: [".pages"],
+    exclude: [],
+  },
+  index: {
+    chunkSize: 500,
+    chunkOverlap: 0,
+    ocrEnabled: false,
+    ocrTriggerMinChars: 100,
+    useSQLiteVSS: false,
+    model: "Xenova/all-MiniLM-L6-v2",
+    maxFileSizeMB: 10,
+    concurrency: 1,
+    languages: ["eng"],
+  },
+  out: { dataDir: ".mcp-nn" },
+};
+
+describe("indexPages", () => {
+  it("returns chunks when XML is present", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "pages-"));
+    const filePath = path.join(dir, "doc.pages");
+    const zip = new AdmZip();
+    zip.addFile("index.xml", Buffer.from("<document><body><p>Antwerp cocaine port report</p></body></document>", "utf8"));
+    zip.writeZip(filePath);
+
+    const chunks = await indexPages({ filePath, mtime: Date.now(), config: baseConfig });
+    expect(chunks.length).toBeGreaterThan(0);
+    expect(chunks[0].text).toContain("Antwerp cocaine port report");
+  });
+
+  it("handles modern pages archives without crashing", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "pages-"));
+    const filePath = path.join(dir, "empty.pages");
+    const zip = new AdmZip();
+    zip.addFile("Data/Document.iwa", Buffer.from("test"));
+    zip.writeZip(filePath);
+
+    const chunks = await indexPages({ filePath, mtime: Date.now(), config: baseConfig });
+    expect(chunks).toEqual([]);
+  });
+});

--- a/tests/store.fallback.test.ts
+++ b/tests/store.fallback.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from "vitest";
+import { tryCreateSQLiteVSS } from "../src/store/vector-sqlitevss.js";
+
+describe("vector-sqlitevss", () => {
+  it("falls back gracefully when sqlite3 is unavailable", async () => {
+    const adapter = await tryCreateSQLiteVSS(".mcp-nn");
+    expect(adapter).toBeUndefined();
+  });
+});

--- a/tests/store.search.test.ts
+++ b/tests/store.search.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import path from "path";
+import os from "os";
+import { promises as fs } from "fs";
+
+vi.mock("pdf-parse", () => ({
+  default: async (_buffer: ArrayBuffer, options: any) => {
+    if (options?.pagerender) {
+      await options.pagerender({
+        getTextContent: async () => ({ items: [] }),
+      });
+    }
+    return {};
+  },
+}));
+
+vi.mock("../src/pipeline/embed.js", () => ({
+  getEmbeddingService: () => ({
+    embed: async (text: string) => {
+      const words = text.split(/\s+/);
+      const dimension = 32;
+      const vector = new Float32Array(dimension);
+      words.forEach((word, idx) => {
+        const value = word.length % 7;
+        vector[idx % dimension] += value;
+      });
+      const norm = Math.hypot(...vector);
+      if (norm) {
+        for (let i = 0; i < vector.length; i++) {
+          vector[i] = vector[i] / norm;
+        }
+      }
+      return vector;
+    },
+  }),
+}));
+
+import { reindexPaths, searchHybrid } from "../src/store/store.js";
+
+const tempDataDir = path.join(os.tmpdir(), `mcp-nn-test-${Date.now()}`);
+const tempDocsDir = path.join(tempDataDir, "docs");
+
+beforeAll(async () => {
+  await fs.mkdir(tempDocsDir, { recursive: true });
+  process.env.MCP_NN_DATA_DIR = tempDataDir;
+  process.env.MCP_NN_ROOTS = tempDocsDir;
+  const filePath = path.join(tempDocsDir, "intel.txt");
+  await fs.writeFile(
+    filePath,
+    [
+      "Antwerp port is a critical hub in the European cocaine supply chain.",
+      "Law enforcement monitors containers using risk scores and historical intel.",
+      "NarcoNations research catalogues seizures across terminals.",
+    ].join(" \n")
+  );
+  await reindexPaths([filePath]);
+});
+
+afterAll(async () => {
+  delete process.env.MCP_NN_DATA_DIR;
+  delete process.env.MCP_NN_ROOTS;
+});
+
+describe("store search", () => {
+  it("returns hybrid search results", async () => {
+    const results = await searchHybrid({ query: "Antwerp port cocaine", k: 3, alpha: 0.5 });
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0].citation.filePath).toContain("intel.txt");
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ESNext",
+    "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "resolveJsonModule": true,
     "esModuleInterop": true,
@@ -10,6 +10,6 @@
     "strict": true,
     "types": ["node"]
   },
-  "include": ["src/**/*.ts"],
+  "include": ["src/**/*.ts", "scripts/**/*.ts", "types/**/*.d.ts"],
   "ts-node": { "esm": true }
 }

--- a/types/pdf-parse.d.ts
+++ b/types/pdf-parse.d.ts
@@ -1,0 +1,12 @@
+declare module "pdf-parse" {
+  interface PdfPage {
+    getTextContent(options?: { normalizeWhitespace?: boolean }): Promise<{ items: Array<{ str?: string }> }>;
+  }
+
+  interface PdfParseOptions {
+    pagerender?: (page: PdfPage) => Promise<string> | string;
+  }
+
+  function pdfParse(data: Uint8Array | ArrayBuffer | Buffer, options?: PdfParseOptions): Promise<{ text: string }>;
+  export = pdfParse;
+}


### PR DESCRIPTION
## Summary
- add shared Zod schema definitions that drive validation across the server and tools
- refactor the MCP server to reuse the schema helper while keeping watcher cleanup and tool output formatting
- introduce the ChatGPT export conversion script plus hybrid search and converter tests for regression coverage

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce2b69f94c83279d381836b9fadcfc