### PR TITLE
feat: build offline research MCP server

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-node_modules
-dist
-.mcp-nn
+node_modules/
+dist/
+.mcp-nn/
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -1,0 +1,172 @@
+# Local Research MCP (mcp-nn)
+
+Offline Model Context Protocol (MCP) server for NarcoNations.org research. Index and search PDF, Markdown, TXT, Word (.docx), and Apple Pages (.pages) with hybrid retrieval (local embeddings + BM25). Returns precise citations (file, page, char ranges, snippet). 100% local. No cloud.
+
+---
+
+## Quickstart
+
+### Requirements
+- Node.js 20+
+- macOS, Linux, or Windows
+
+```bash
+# 1) Install dependencies
+npm install
+
+# 2) (Optional) Prefetch the embedding model for fully offline use
+npm run models:download
+
+# 3) Index your folders
+npm run index -- ./docs ./public/dossiers ./pdfs
+
+# 4) Run the MCP server (stdio)
+npm run dev
+```
+
+### Example MCP tool calls
+
+**search_local**
+```json
+{
+  "tool": "search_local",
+  "input": { "query": "Antwerp cocaine port", "k": 8, "alpha": 0.65 }
+}
+```
+
+**get_doc**
+```json
+{
+  "tool": "get_doc",
+  "input": { "path": "./docs/ports/antwerp.pdf", "page": 12 }
+}
+```
+
+---
+
+## ChatGPT → ZIP → Markdown → Index
+
+1. Export chats from ChatGPT (Settings → Data Controls → Export) and unzip locally.
+2. Convert the export to Markdown:
+   ```bash
+   npm run chatgpt:to-md -- ~/Downloads/chatgpt-export
+   ```
+   Files are written to `./docs/chatgpt-export-md` by default.
+3. Index the converted chats:
+   ```bash
+   npm run index -- ./docs/chatgpt-export-md
+   ```
+4. Search from your MCP client:
+   ```json
+   { "tool": "search_local", "input": { "query": "Antwerp cocaine port", "k": 8 } }
+   ```
+
+**One-shot MCP tool**
+
+```
+import_chatgpt_export {
+  "exportPath": "~/Downloads/chatgpt-export",
+  "outDir": "./docs/chatgpt-export-md"
+}
+```
+
+> Privacy: Chat exports may contain sensitive information. Keep them local.
+
+---
+
+## Configuration
+
+After first run, inspect `.mcp-nn/config.json`. Defaults:
+
+```json
+{
+  "roots": {
+    "roots": ["./docs", "./public/dossiers", "./docs/chatgpt-export-md"],
+    "include": [".pdf", ".md", ".txt", ".docx", ".pages"],
+    "exclude": ["**/node_modules/**", ".git/**"]
+  },
+  "index": {
+    "chunkSize": 3500,
+    "chunkOverlap": 120,
+    "ocrEnabled": true,
+    "ocrTriggerMinChars": 100,
+    "useSQLiteVSS": false,
+    "model": "Xenova/all-MiniLM-L6-v2",
+    "maxFileSizeMB": 200,
+    "concurrency": 2,
+    "languages": ["eng"]
+  },
+  "out": { "dataDir": ".mcp-nn" }
+}
+```
+
+Environment overrides:
+- `MCP_NN_DATA_DIR` – change index storage directory.
+- `TRANSFORMERS_CACHE` – control model cache location.
+- `TRANSFORMERS_OFFLINE=1` – force fully offline model loads.
+
+---
+
+## File Types & Caveats
+
+- **PDF**: Uses `pdf-parse`. Pages with scarce text are flagged and logged; files continue indexing.
+- **Markdown**: `gray-matter` preserves front-matter metadata.
+- **Word (.docx)**: `mammoth` extracts clean text.
+- **Pages (.pages)**: Parsed with `adm-zip` + `fast-xml-parser`. Modern `.iwa` bundles set `partial: true` and log a warning.
+
+---
+
+## Performance Tips
+
+- First embedding model load on CPU: ~10–30s, then cached.
+- Enable OCR only when handling scanned PDFs; otherwise increase `ocrTriggerMinChars` or disable OCR.
+- For large corpora (> ~50k chunks), consider enabling SQLite VSS once the extension is available.
+
+---
+
+## Security & Privacy
+
+- Strict roots whitelist with realpath checks; paths outside the configured roots are rejected.
+- Zip handling guards against ZipSlip.
+- Default offline; no outbound calls unless you add them.
+- Treat ChatGPT exports as sensitive data and keep them within local roots.
+
+---
+
+## Troubleshooting
+
+- **Slow OCR**: Increase `ocrTriggerMinChars` or disable OCR for digital PDFs.
+- **Model will not load offline**: Run `npm run models:download` and set `TRANSFORMERS_OFFLINE=1`.
+- **sqlite-vss unavailable**: The server falls back to the flat vector index automatically.
+- **Pages marked partial**: Export the `.pages` document to `.docx` or `.pdf` for full fidelity.
+- **Chat export errors**: Ensure `conversations.json` exists in the provided folder.
+
+---
+
+## Tests
+
+```bash
+npm test
+```
+
+Runs Vitest offline (embeddings are mocked). Real-model tests require `npm run models:download` beforehand.
+
+---
+
+## Styling & Conventions
+
+- TypeScript strict mode; prefer small, pure functions with early returns.
+- VerbNoun function names, PascalCase types, camelCase variables.
+- Modules ~200 lines max; split by concern (`indexers/`, `pipeline/`, `store/`, `tools/`).
+- Comments explain “why”, not “what”.
+- Errors include concise messages and affected paths.
+- Logging emits single-line JSON: `{ level, msg, time, ... }`; DEBUG controlled via env.
+- Tool I/O validated with Zod; outputs stay JSON-serializable with explicit fields.
+- Docs written in imperative mood (“Run…”, “Use…”).
+- Offline-first: no network calls after model download.
+
+---
+
+## License
+
+MIT

--- a/fixtures/chatgpt-export-sample/conversations.json
+++ b/fixtures/chatgpt-export-sample/conversations.json
@@ -1,0 +1,22 @@
+[
+  {
+    "id": "conv-1",
+    "title": "Sample Chat",
+    "create_time": 1710000000,
+    "model_slug": "gpt-4",
+    "messages": [
+      {
+        "id": "m1",
+        "author": { "role": "user" },
+        "content": { "parts": ["Hello"] },
+        "create_time": 1710000000
+      },
+      {
+        "id": "m2",
+        "author": { "role": "assistant" },
+        "content": { "parts": ["Hi there"] },
+        "create_time": 1710000001
+      }
+    ]
+  }
+]

--- a/mcp.json
+++ b/mcp.json
@@ -1,0 +1,11 @@
+{
+  "name": "mcp-nn",
+  "version": "1.1.0",
+  "description": "Offline MCP server for NarcoNations.org research corpus",
+  "transport": {
+    "type": "stdio",
+    "command": "node",
+    "args": ["dist/server.js"]
+  },
+  "tools": ["search_local", "get_doc", "reindex", "watch", "stats", "import_chatgpt_export"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "mcp-nn",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-nn",
-      "version": "1.0.0",
-      "license": "ISC",
+      "version": "1.1.0",
+      "license": "MIT",
       "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.18.1",
         "@xenova/transformers": "^2.17.2",
         "adm-zip": "^0.5.16",
         "chokidar": "^4.0.3",
@@ -633,6 +634,47 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.18.1.tgz",
+      "integrity": "sha512-d//GE8/Yh7aC3e7p+kZG8JqqEAwwDUmAfvH1quogtbk+ksS6E0RR6toKKESPYYZVre0meqkJb27zb+dhqE9Sgw==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.6",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.0.1",
+        "express-rate-limit": "^7.5.0",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.23.8",
+        "zod-to-json-schema": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/zod-to-json-schema": {
+      "version": "3.24.6",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
+      "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.24.1"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -1331,6 +1373,28 @@
       "license": "ISC",
       "optional": true
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -1422,6 +1486,22 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/ansi-regex": {
@@ -1682,6 +1762,43 @@
       "integrity": "sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw==",
       "license": "MIT"
     },
+    "node_modules/body-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
+      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.0",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.6.3",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.0",
+        "raw-body": "^3.0.0",
+        "type-is": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/body-parser/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -1734,6 +1851,15 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "license": "MIT"
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/cac": {
       "version": "6.7.14",
@@ -1800,6 +1926,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/chai": {
@@ -1925,11 +2080,83 @@
       "license": "ISC",
       "optional": true
     },
+    "node_modules/content-disposition": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
+      "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-disposition/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/create-require": {
       "version": "1.1.1",
@@ -1942,7 +2169,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -2003,6 +2229,15 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.0.tgz",
@@ -2037,11 +2272,31 @@
         "underscore": "^1.13.1"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
     },
     "node_modules/emoji-regex": {
@@ -2050,6 +2305,15 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/encoding": {
       "version": "0.1.13",
@@ -2087,12 +2351,42 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.25.10",
@@ -2136,6 +2430,12 @@
         "@esbuild/win32-x64": "0.25.10"
       }
     },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -2159,6 +2459,36 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/expand-template": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
@@ -2178,6 +2508,80 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/express": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
+      "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.0",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
+      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/express/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/extend-shallow": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
@@ -2189,6 +2593,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
     },
     "node_modules/fast-fifo": {
       "version": "1.3.2",
@@ -2211,6 +2621,12 @@
       "engines": {
         "node": ">=8.6.0"
       }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "license": "MIT"
     },
     "node_modules/fast-xml-parser": {
       "version": "5.2.5",
@@ -2256,6 +2672,40 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
+      "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/finalhandler/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/flatbuffers": {
@@ -2322,6 +2772,24 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -2363,6 +2831,15 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gauge": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
@@ -2382,6 +2859,43 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-tsconfig": {
@@ -2437,6 +2951,18 @@
         "node": ">= 6"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -2465,6 +2991,18 @@
       "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==",
       "license": "ISC"
     },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
@@ -2472,12 +3010,49 @@
       "license": "ISC",
       "optional": true
     },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/http-cache-semantics": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
       "license": "BSD-2-Clause",
       "optional": true
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-errors/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/http-proxy-agent": {
       "version": "4.0.1",
@@ -2559,7 +3134,6 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -2660,6 +3234,15 @@
         "node": ">= 12"
       }
     },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
@@ -2722,6 +3305,12 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/is-url": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
@@ -2738,7 +3327,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/jackspeak": {
@@ -2776,6 +3364,12 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "license": "MIT"
     },
     "node_modules/jszip": {
       "version": "3.10.1",
@@ -2913,6 +3507,36 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -2933,6 +3557,27 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/mimic-response": {
@@ -3245,6 +3890,39 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -3342,6 +4020,15 @@
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
       "license": "(MIT AND Zlib)"
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -3355,7 +4042,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3396,6 +4082,16 @@
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/pathe": {
@@ -3445,6 +4141,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.0.tgz",
+      "integrity": "sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/platform": {
@@ -3603,6 +4308,19 @@
         "pbts": "bin/pbts"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/pump": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
@@ -3611,6 +4329,30 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/queue-microtask": {
@@ -3632,6 +4374,46 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.1.tgz",
+      "integrity": "sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.7.0",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
+      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/rc": {
       "version": "1.2.8",
@@ -3824,6 +4606,39 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -3857,8 +4672,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/section-matter": {
       "version": "1.0.0",
@@ -3885,6 +4699,60 @@
         "node": ">=10"
       }
     },
+    "node_modules/send": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
+      "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "mime-types": "^3.0.1",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/send/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -3897,6 +4765,12 @@
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
       "license": "MIT"
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
     },
     "node_modules/sharp": {
       "version": "0.32.6",
@@ -3925,7 +4799,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -3938,10 +4811,81 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/siginfo": {
@@ -4157,6 +5101,15 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/std-env": {
       "version": "3.9.0",
@@ -4488,6 +5441,15 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -4570,6 +5532,20 @@
         "node": "*"
       }
     },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
@@ -4616,6 +5592,24 @@
         "imurmurhash": "^0.1.4"
       }
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -4641,6 +5635,15 @@
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/vite": {
       "version": "7.1.6",
@@ -4919,7 +5922,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -1,31 +1,32 @@
 {
   "name": "mcp-nn",
-  "version": "1.0.0",
-  "main": "index.js",
+  "version": "1.1.0",
+  "description": "Offline MCP server for NarcoNations.org research corpus",
+  "type": "module",
+  "license": "MIT",
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "scripts": {
-    "test": "vitest run",
     "dev": "tsx src/server.ts",
     "start": "node --enable-source-maps dist/server.js",
     "build": "tsc -p tsconfig.json",
     "index": "ts-node src/cli-index.ts",
     "watch": "ts-node src/cli-watch.ts",
+    "test": "vitest run",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
     "models:download": "node scripts/prefetch-model.mjs",
     "clean": "rimraf .mcp-nn dist",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
-  },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
-  "description": "",
-  "type": "module",
-  "engines": {
-    "node": ">=20.0.0"
+    "chatgpt:to-md": "ts-node scripts/chatgpt-export-to-md.ts",
+    "chatgpt:index": "ts-node scripts/chatgpt-export-to-md.ts ./fixtures/chatgpt-export-sample && ts-node src/cli-index.ts ./docs/chatgpt-export-md",
+    "chatgpt:quickstart": "npm run chatgpt:to-md -- ~/Downloads/chatgpt-export && npm run index -- ./docs/chatgpt-export-md"
   },
   "ts-node": {
-    "esm": "true",
-    "transpileOnly": "true"
+    "esm": true,
+    "transpileOnly": true
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.18.1",
     "@xenova/transformers": "^2.17.2",
     "adm-zip": "^0.5.16",
     "chokidar": "^4.0.3",

--- a/scripts/chatgpt-export-to-md.ts
+++ b/scripts/chatgpt-export-to-md.ts
@@ -1,0 +1,24 @@
+// scripts/chatgpt-export-to-md.ts
+// Usage: npm run chatgpt:to-md -- /path/to/ChatGPT-export [outDir]
+import { convertChatGPTExport } from "../src/chatgpt/convert.js";
+
+async function main() {
+  const argIdx = process.argv.findIndex((a) => a === "--");
+  const exportRoot = process.argv[argIdx >= 0 ? argIdx + 1 : 2] as string | undefined;
+  const outDirArg = process.argv[argIdx >= 0 ? argIdx + 2 : 3] as string | undefined;
+  if (!exportRoot) {
+    console.error("Usage: npm run chatgpt:to-md -- /path/to/ChatGPT-export [outDir]");
+    process.exit(1);
+  }
+  try {
+    const result = await convertChatGPTExport(exportRoot, outDirArg);
+    console.log(JSON.stringify({ level: "info", msg: "chatgpt_export_converted", meta: result }));
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  }
+}
+
+if (process.argv[1]?.endsWith("chatgpt-export-to-md.ts")) {
+  main();
+}

--- a/src/chatgpt/convert.ts
+++ b/src/chatgpt/convert.ts
@@ -1,0 +1,121 @@
+import { promises as fs } from "fs";
+import path from "path";
+import crypto from "crypto";
+
+type AnyMsg = any;
+type AnyConv = any;
+
+const outDirDefault = path.join(process.cwd(), "docs", "chatgpt-export-md");
+const toISO = (n?: number) => (n ? new Date(n > 2e10 ? n : n * 1000).toISOString() : new Date().toISOString());
+
+const slug = (s: string) =>
+  (s || "untitled")
+    .toLowerCase()
+    .replace(/[^\w\-]+/g, "-")
+    .replace(/\-+/g, "-")
+    .replace(/(^\-|\-$)/g, "")
+    .slice(0, 80) || "untitled";
+
+function asText(content: any): string {
+  if (!content) return "";
+  if (Array.isArray(content)) {
+    const parts = content.map((c: any) => c?.text?.value ?? c?.string_value ?? "").filter(Boolean);
+    if (parts.length) return parts.join("\n\n");
+  }
+  if (content?.parts && Array.isArray(content.parts)) return content.parts.join("\n\n");
+  if (typeof content === "string") return content;
+  return JSON.stringify(content, null, 2);
+}
+
+function extractMessages(conv: AnyConv): { role: string; text: string; ts?: number }[] {
+  if (Array.isArray(conv?.messages)) {
+    return conv.messages
+      .map((m: AnyMsg) => ({
+        role: m?.author?.role || m?.role || "unknown",
+        text: asText(m?.content || m?.text),
+        ts: m?.create_time || m?.timestamp || m?.create_time_ms,
+      }))
+      .filter((m: { role: string; text: string; ts?: number }) => m.text?.trim());
+  }
+  if (conv?.mapping && typeof conv.mapping === "object") {
+    const msgs = Object.values(conv.mapping)
+      .map((n: any) => n?.message)
+      .filter(Boolean)
+      .map((m: any) => ({
+        role: m?.author?.role || m?.role || "unknown",
+        text: asText(m?.content),
+        ts: m?.create_time || m?.timestamp || m?.create_time_ms,
+      }))
+      .filter((m: { role: string; text: string; ts?: number }) => m.text?.trim());
+    return msgs.sort((a, b) => (a.ts ?? 0) - (b.ts ?? 0));
+  }
+  if (conv?.conversation?.messages) return extractMessages(conv.conversation);
+  return [];
+}
+
+async function loadExportJson(exportRoot: string): Promise<any> {
+  const candidates = [
+    path.join(exportRoot, "conversations.json"),
+    path.join(exportRoot, "conversations", "conversations.json"),
+    path.join(exportRoot, "export.json"),
+  ];
+  for (const p of candidates) {
+    try {
+      const raw = await fs.readFile(p, "utf8");
+      return JSON.parse(raw);
+    } catch {}
+  }
+  throw new Error(`Could not find conversations.json in ${exportRoot}`);
+}
+
+async function ensureDir(p: string) {
+  await fs.mkdir(p, { recursive: true });
+}
+
+export async function convertChatGPTExport(exportRoot: string, outDirArg?: string) {
+  const data = await loadExportJson(exportRoot);
+  const conversations: AnyConv[] = Array.isArray(data) ? data : data.conversations ?? [];
+  if (!Array.isArray(conversations) || conversations.length === 0) {
+    throw new Error("No conversations found in export.");
+  }
+
+  const outDir = outDirArg || outDirDefault;
+  await ensureDir(outDir);
+
+  let written = 0;
+  for (const conv of conversations) {
+    const id: string = conv.id || conv.conversation_id || crypto.randomBytes(6).toString("hex");
+    const title: string = (conv.title || conv.gist || "Untitled").trim();
+    const created: number = conv.create_time || conv.create_time_unix || conv.create_time_ms || Date.now();
+    const model: string = conv.model_slug || conv.model || "";
+    const msgs = extractMessages(conv);
+
+    const header = [
+      "---",
+      `id: ${JSON.stringify(id)}`,
+      `title: ${JSON.stringify(title)}`,
+      `created: ${JSON.stringify(toISO(created))}`,
+      `model: ${JSON.stringify(model)}`,
+      "source: \"chatgpt-export\"",
+      "---",
+      "",
+      `# ${title}`,
+      "",
+    ].join("\n");
+
+    const body = msgs
+      .map((m) => {
+        const role = m.role === "system" ? "system" : m.role?.replace(/^assistant$/, "assistant").replace(/^user$/, "user");
+        const when = m.ts ? toISO(m.ts) : "";
+        const text = (m.text || "").normalize("NFKC").trim();
+        return `## ${role}${when ? ` • ${when}` : ""}\n\n${text}\n`;
+      })
+      .join("\n");
+
+    const fname = `${slug(title)}-${id.slice(0, 8)}.md`;
+    await fs.writeFile(path.join(outDir, fname), `${header}${body}`, "utf8");
+    written++;
+  }
+
+  return { conversations: conversations.length, filesWritten: written, outDir };
+}

--- a/src/cli-index.ts
+++ b/src/cli-index.ts
@@ -1,1 +1,17 @@
-console.log(JSON.stringify({ level: 'info', msg: 'index CLI stub — Codex will implement reindex(paths...)' }));
+import { loadConfig } from "./config.js";
+import { ResearchStore } from "./store/store.js";
+import { logger } from "./utils/logger.js";
+
+async function main() {
+  const { config } = await loadConfig();
+  const store = new ResearchStore(config);
+  await store.ready();
+  const paths = process.argv.slice(2);
+  const summary = await store.reindex(paths);
+  logger.info("reindex-complete", { ...summary });
+}
+
+main().catch((err) => {
+  logger.error("cli-index-failed", { err: err instanceof Error ? err.message : String(err) });
+  process.exit(1);
+});

--- a/src/cli-watch.ts
+++ b/src/cli-watch.ts
@@ -1,1 +1,27 @@
-console.log(JSON.stringify({ level: 'info', msg: 'watch CLI stub — Codex will implement chokidar + events' }));
+import { loadConfig } from "./config.js";
+import { ResearchStore } from "./store/store.js";
+import { logger } from "./utils/logger.js";
+
+async function main() {
+  const { config } = await loadConfig();
+  const store = new ResearchStore(config);
+  await store.ready();
+  const paths = process.argv.slice(2);
+  const close = await store.watch(paths, (event: { event: string; path: string }) => logger.info("watch", event));
+
+  const shutdown = async () => {
+    logger.info("watch-stop", {});
+    await close();
+    process.exit(0);
+  };
+
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
+
+  await new Promise(() => {});
+}
+
+main().catch((err) => {
+  logger.error("cli-watch-failed", { err: err instanceof Error ? err.message : String(err) });
+  process.exit(1);
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,100 @@
+import { promises as fs } from "fs";
+import path from "path";
+
+export interface RootsConfig {
+  roots: string[];
+  include: string[];
+  exclude: string[];
+}
+
+export interface IndexConfig {
+  chunkSize: number;
+  chunkOverlap: number;
+  ocrEnabled: boolean;
+  ocrTriggerMinChars: number;
+  useSQLiteVSS: boolean;
+  model: string;
+  maxFileSizeMB?: number;
+  concurrency?: number;
+  languages?: string[];
+}
+
+export interface OutConfig {
+  dataDir: string;
+  modelCacheDir?: string;
+}
+
+export interface AppConfig {
+  roots: RootsConfig;
+  index: IndexConfig;
+  out: OutConfig;
+}
+
+const DEFAULT_CONFIG: AppConfig = {
+  roots: {
+    roots: ["./docs", "./public/dossiers", "./docs/chatgpt-export-md"],
+    include: [".pdf", ".md", ".txt", ".docx", ".pages"],
+    exclude: ["**/node_modules/**", ".git/**"],
+  },
+  index: {
+    chunkSize: 3500,
+    chunkOverlap: 120,
+    ocrEnabled: true,
+    ocrTriggerMinChars: 100,
+    useSQLiteVSS: false,
+    model: "Xenova/all-MiniLM-L6-v2",
+    maxFileSizeMB: 200,
+    concurrency: 2,
+    languages: ["eng"],
+  },
+  out: {
+    dataDir: ".mcp-nn",
+  },
+};
+
+export interface ConfigLoadResult {
+  config: AppConfig;
+  configPath: string;
+}
+
+async function pathExists(p: string): Promise<boolean> {
+  try {
+    await fs.access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function loadConfig(): Promise<ConfigLoadResult> {
+  const dataDir = process.env.MCP_NN_DATA_DIR || DEFAULT_CONFIG.out.dataDir;
+  const resolvedDataDir = path.resolve(process.cwd(), dataDir);
+  await fs.mkdir(resolvedDataDir, { recursive: true });
+
+  const configPath = path.join(resolvedDataDir, "config.json");
+  let config: AppConfig = structuredClone(DEFAULT_CONFIG);
+
+  if (await pathExists(configPath)) {
+    try {
+      const raw = await fs.readFile(configPath, "utf8");
+      const parsed = JSON.parse(raw);
+      config = {
+        roots: { ...DEFAULT_CONFIG.roots, ...(parsed.roots ?? {}) },
+        index: { ...DEFAULT_CONFIG.index, ...(parsed.index ?? {}) },
+        out: { ...DEFAULT_CONFIG.out, ...(parsed.out ?? {}) },
+      };
+    } catch {
+      // fall back to defaults and overwrite below
+    }
+  }
+
+  if (process.env.TRANSFORMERS_CACHE) {
+    config.out.modelCacheDir = process.env.TRANSFORMERS_CACHE;
+  }
+
+  if (!(await pathExists(configPath))) {
+    await fs.writeFile(configPath, JSON.stringify(config, null, 2), "utf8");
+  }
+
+  return { config, configPath };
+}

--- a/src/indexers/markdown.ts
+++ b/src/indexers/markdown.ts
@@ -1,0 +1,17 @@
+import { promises as fs } from "fs";
+import matter from "gray-matter";
+import { IndexFileResult } from "../types.js";
+import { ChunkOptions, chunkSource } from "../pipeline/chunk.js";
+import { hashContent } from "../utils/hash.js";
+
+export async function indexMarkdown(filePath: string, mtime: number, options: ChunkOptions): Promise<IndexFileResult> {
+  const raw = await fs.readFile(filePath, "utf8");
+  const parsed = matter(raw);
+  const tags: string[] | undefined = Array.isArray(parsed.data?.tags)
+    ? parsed.data.tags.map((t: unknown) => String(t))
+    : undefined;
+  const text = `${parsed.data?.title ? `# ${parsed.data.title}\n\n` : ""}${parsed.content}`;
+  const chunks = chunkSource({ path: filePath, type: "markdown", text, mtime, tags }, options);
+  const fileHash = hashContent(raw);
+  return { chunks, fullText: text, tags, fileHash };
+}

--- a/src/indexers/pages.ts
+++ b/src/indexers/pages.ts
@@ -1,0 +1,50 @@
+import { promises as fs } from "fs";
+import AdmZip from "adm-zip";
+import { XMLParser } from "fast-xml-parser";
+import { IndexFileResult } from "../types.js";
+import { ChunkOptions, chunkSource } from "../pipeline/chunk.js";
+import { logger } from "../utils/logger.js";
+import { hashBuffer } from "../utils/hash.js";
+
+function flattenText(node: unknown): string {
+  if (node == null) return "";
+  if (typeof node === "string" || typeof node === "number") {
+    return String(node);
+  }
+  if (Array.isArray(node)) {
+    return node.map((item) => flattenText(item)).join(" ");
+  }
+  if (typeof node === "object") {
+    return Object.values(node)
+      .map((value) => flattenText(value))
+      .join(" ");
+  }
+  return "";
+}
+
+export async function indexPages(filePath: string, mtime: number, options: ChunkOptions): Promise<IndexFileResult> {
+  const buffer = await fs.readFile(filePath);
+  const zip = new AdmZip(buffer);
+  const entries = zip.getEntries();
+  let text = "";
+  let partial = false;
+
+  const indexEntry = entries.find((entry) => entry.entryName.endsWith("index.xml") || entry.entryName.endsWith("index.apxl"));
+
+  if (indexEntry) {
+    const xml = indexEntry.getData().toString("utf8");
+    const parser = new XMLParser({ ignoreAttributes: false });
+    const parsed = parser.parse(xml);
+    text = flattenText(parsed).replace(/\s+/g, " ").trim();
+  } else {
+    const iwaEntries = entries.filter((entry) => entry.entryName.endsWith(".iwa"));
+    if (iwaEntries.length > 0) {
+      partial = true;
+      logger.warn("pages-iwa-unparsed", { path: filePath, entries: iwaEntries.length });
+    }
+  }
+
+  const chunks = chunkSource({ path: filePath, type: "pages", text, mtime, partial }, options);
+  const fileHash = hashBuffer(buffer);
+  return { chunks, fullText: text, partial, fileHash };
+}

--- a/src/indexers/pdf.ts
+++ b/src/indexers/pdf.ts
@@ -1,0 +1,54 @@
+import { promises as fs } from "fs";
+import pdfParse from "pdf-parse/lib/pdf-parse.js";
+import { IndexConfig } from "../config.js";
+import { IndexFileResult } from "../types.js";
+import { ChunkOptions, chunkSource } from "../pipeline/chunk.js";
+import { shouldRunOcr } from "../pipeline/detect-ocr.js";
+import { logger } from "../utils/logger.js";
+import { hashBuffer } from "../utils/hash.js";
+
+export async function indexPdf(
+  filePath: string,
+  mtime: number,
+  options: ChunkOptions,
+  config: IndexConfig,
+): Promise<IndexFileResult> {
+  const buffer = await fs.readFile(filePath);
+  const pageTexts: string[] = [];
+  const parsed = await pdfParse(buffer, {
+    pagerender: async (pageData: any) => {
+      const textContent = await pageData.getTextContent();
+      const text = textContent.items.map((item: any) => item.str || "").join("\n");
+      pageTexts.push(text);
+      return text;
+    },
+  });
+
+  if (pageTexts.length === 0 && parsed.text) {
+    pageTexts.push(parsed.text);
+  }
+
+  const chunks = pageTexts.flatMap((text, idx) => {
+    const decision = shouldRunOcr(text, config);
+    const needsOcr = decision.shouldRun;
+    if (needsOcr) {
+      logger.warn("pdf-ocr-fallback-unavailable", { path: filePath, page: idx + 1, reason: decision.reason });
+    }
+    return chunkSource(
+      {
+        path: filePath,
+        type: "pdf",
+        text,
+        mtime,
+        page: idx + 1,
+        partial: needsOcr,
+      },
+      options,
+    );
+  });
+
+  const partial = chunks.some((chunk) => chunk.partial);
+
+  const fileHash = hashBuffer(buffer);
+  return { chunks, pages: pageTexts, partial, fileHash };
+}

--- a/src/indexers/text.ts
+++ b/src/indexers/text.ts
@@ -1,0 +1,11 @@
+import { promises as fs } from "fs";
+import { IndexFileResult } from "../types.js";
+import { hashContent } from "../utils/hash.js";
+import { ChunkOptions, chunkSource } from "../pipeline/chunk.js";
+
+export async function indexText(filePath: string, mtime: number, options: ChunkOptions): Promise<IndexFileResult> {
+  const text = await fs.readFile(filePath, "utf8");
+  const chunks = chunkSource({ path: filePath, type: "text", text, mtime }, options);
+  const fileHash = hashContent(text);
+  return { chunks, fullText: text, fileHash };
+}

--- a/src/indexers/word.ts
+++ b/src/indexers/word.ts
@@ -1,0 +1,14 @@
+import { promises as fs } from "fs";
+import mammoth from "mammoth";
+import { IndexFileResult } from "../types.js";
+import { ChunkOptions, chunkSource } from "../pipeline/chunk.js";
+import { hashBuffer } from "../utils/hash.js";
+
+export async function indexWord(filePath: string, mtime: number, options: ChunkOptions): Promise<IndexFileResult> {
+  const buffer = await fs.readFile(filePath);
+  const result = await mammoth.extractRawText({ buffer });
+  const text = result.value ?? "";
+  const chunks = chunkSource({ path: filePath, type: "word", text, mtime }, options);
+  const fileHash = hashBuffer(buffer);
+  return { chunks, fullText: text, fileHash };
+}

--- a/src/pipeline/chunk.ts
+++ b/src/pipeline/chunk.ts
@@ -1,0 +1,88 @@
+import { createChunkId, hashChunkInput } from "../utils/hash.js";
+import { Chunk, ChunkKind } from "../types.js";
+
+export interface ChunkOptions {
+  chunkSize: number;
+  chunkOverlap: number;
+}
+
+export interface ChunkSource {
+  path: string;
+  type: ChunkKind;
+  text: string;
+  mtime: number;
+  page?: number;
+  tags?: string[];
+  partial?: boolean;
+}
+
+function normalize(text: string): string {
+  return text.replace(/\r\n/g, "\n").replace(/\u0000/g, " ").normalize("NFKC");
+}
+
+function breakIntoParagraphs(text: string): string[] {
+  const normalized = normalize(text).trim();
+  if (!normalized) return [];
+  return normalized.split(/\n{2,}/g).map((p) => p.trim()).filter(Boolean);
+}
+
+export function chunkSource(source: ChunkSource, options: ChunkOptions): Chunk[] {
+  const paragraphs = breakIntoParagraphs(source.text);
+  if (paragraphs.length === 0) {
+    const id = createChunkId(source.path, source.page, 0, source.text.length);
+    return [
+      {
+        id,
+        path: source.path,
+        type: source.type,
+        page: source.page,
+        offsetStart: 0,
+        offsetEnd: source.text.length,
+        text: normalize(source.text),
+        tags: source.tags,
+        partial: source.partial,
+        mtime: source.mtime,
+        tokens: Math.round(source.text.length / 5),
+      },
+    ];
+  }
+
+  const chunks: Chunk[] = [];
+  const { chunkSize, chunkOverlap } = options;
+  let cursor = 0;
+
+  for (const paragraph of paragraphs) {
+    const paraWithBreak = paragraph.endsWith("\n") ? paragraph : `${paragraph}\n\n`;
+    let start = 0;
+    while (start < paraWithBreak.length) {
+      const available = paraWithBreak.length - start;
+      const take = Math.min(chunkSize, available);
+      const piece = paraWithBreak.slice(start, start + take);
+      const globalStart = cursor + start;
+      const globalEnd = globalStart + piece.length;
+      const id = createChunkId(source.path, source.page, globalStart, globalEnd);
+      chunks.push({
+        id,
+        path: source.path,
+        type: source.type,
+        page: source.page,
+        offsetStart: globalStart,
+        offsetEnd: globalEnd,
+        text: piece,
+        tags: source.tags,
+        partial: source.partial,
+        mtime: source.mtime,
+        tokens: Math.round(piece.length / 5),
+      });
+      if (available <= chunkSize) break;
+      start += chunkSize - chunkOverlap;
+    }
+    cursor += paraWithBreak.length;
+  }
+
+  return chunks;
+}
+
+export function computeChunkHash(chunk: Chunk): string {
+  return hashChunkInput(chunk.path, chunk.mtime, `${chunk.page ?? ""}|${chunk.offsetStart ?? 0}|${chunk.offsetEnd ?? 0}|${chunk.text}`);
+}

--- a/src/pipeline/detect-ocr.ts
+++ b/src/pipeline/detect-ocr.ts
@@ -1,0 +1,17 @@
+import { IndexConfig } from "../config.js";
+
+export interface OcrDecision {
+  shouldRun: boolean;
+  reason: string;
+}
+
+export function shouldRunOcr(text: string, config: IndexConfig): OcrDecision {
+  if (!config.ocrEnabled) {
+    return { shouldRun: false, reason: "ocr-disabled" };
+  }
+  const length = text.replace(/\s+/g, "").length;
+  if (length >= config.ocrTriggerMinChars) {
+    return { shouldRun: false, reason: "enough-text" };
+  }
+  return { shouldRun: true, reason: "low-density" };
+}

--- a/src/pipeline/embed.ts
+++ b/src/pipeline/embed.ts
@@ -1,0 +1,46 @@
+import { pipeline } from "@xenova/transformers";
+import { logger } from "../utils/logger.js";
+
+let extractorPromise: Promise<any> | null = null;
+let statusCallback: ((status: "loading" | "ready") => void) | null = null;
+let isLoading = false;
+let isReady = false;
+
+export function onModelStatus(cb: (status: "loading" | "ready") => void) {
+  statusCallback = cb;
+  if (isLoading || extractorPromise) {
+    statusCallback?.("loading");
+  }
+  if (isReady) {
+    statusCallback?.("ready");
+  }
+}
+
+async function getExtractor(model: string): Promise<any> {
+  if (!extractorPromise) {
+    isLoading = true;
+    statusCallback?.("loading");
+    extractorPromise = pipeline("feature-extraction", model).then((pipe) => {
+      isReady = true;
+      isLoading = false;
+      statusCallback?.("ready");
+      logger.info("embedding-model-ready", { model });
+      return pipe;
+    });
+  }
+  return extractorPromise;
+}
+
+export async function embedText(text: string, model: string): Promise<Float32Array> {
+  const extractor = await getExtractor(model);
+  const output = await extractor(text, { pooling: "mean", normalize: true });
+  if (Array.isArray(output)) {
+    const array = output[0] as number[];
+    return Float32Array.from(array);
+  }
+  if (output?.data) {
+    return Float32Array.from(output.data as number[]);
+  }
+  const values = (output as number[]) ?? [];
+  return Float32Array.from(values);
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,16 +1,135 @@
-import 'source-map-support/register';
+import "source-map-support/register";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { loadConfig } from "./config.js";
+import { ResearchStore } from "./store/store.js";
+import { logger } from "./utils/logger.js";
+import { searchLocalSpec, handleSearchLocal } from "./tools/searchLocal.js";
+import { getDocSpec, handleGetDoc } from "./tools/getDoc.js";
+import { reindexSpec, handleReindex } from "./tools/reindex.js";
+import { statsSpec, handleStats } from "./tools/stats.js";
+import { watchSpec, handleWatch } from "./tools/watch.js";
+import { importChatGPTSpec, handleImportChatGPT } from "./tools/importChatGPT.js";
+import { onModelStatus } from "./pipeline/embed.js";
 
-function log(level: string, msg: string, meta: Record<string, unknown> = {}) {
-  process.stdout.write(JSON.stringify({ level, msg, ...meta }) + '\n');
+function asResult(data: unknown) {
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify(data, null, 2),
+      },
+    ],
+  };
 }
 
 async function main() {
-  log('info', 'mcp-nn skeleton ready', { mode: 'dev', transport: 'stdio' });
-  // Codex will replace this with the real MCP stdio server and tool registrations.
-  process.stdin.resume();
+  const { config } = await loadConfig();
+  const store = new ResearchStore(config);
+  await store.ready();
+
+  const server = new McpServer({ name: "mcp-nn", version: "1.1.0" }, {
+    instructions:
+      "Local research MCP server. Use search_local, get_doc, reindex, watch, stats, and import_chatgpt_export to manage the corpus.",
+  });
+
+  const activeWatchers: Array<() => Promise<void>> = [];
+
+  onModelStatus(async (status) => {
+    await server.server.sendLoggingMessage({ level: "info", message: JSON.stringify({ event: "model", status }) });
+  });
+
+  server.registerTool(
+    searchLocalSpec.name,
+    {
+      description: searchLocalSpec.description,
+    },
+    async (args) => {
+      const data = await handleSearchLocal(store, args);
+      return asResult(data);
+    },
+  );
+
+  server.registerTool(
+    getDocSpec.name,
+    {
+      description: getDocSpec.description,
+    },
+    async (args) => {
+      const doc = await handleGetDoc(store, args);
+      return asResult(doc);
+    },
+  );
+
+  server.registerTool(
+    reindexSpec.name,
+    {
+      description: reindexSpec.description,
+    },
+    async (args) => {
+      const summary = await handleReindex(store, args);
+      return asResult(summary);
+    },
+  );
+
+  server.registerTool(
+    statsSpec.name,
+    { description: statsSpec.description },
+    async () => {
+      const stats = await handleStats(store);
+      return asResult(stats);
+    },
+  );
+
+  server.registerTool(
+    watchSpec.name,
+    {
+      description: watchSpec.description,
+    },
+    async (args, extra) => {
+      const { result, close } = await handleWatch(store, args, async (event) => {
+        const payload = { event: "watch", action: event.event, path: event.path };
+        await server.server.sendLoggingMessage({ level: "info", message: JSON.stringify(payload) }, extra.sessionId);
+      });
+      activeWatchers.push(close);
+      return asResult({ watching: result.watching });
+    },
+  );
+
+  server.registerTool(
+    importChatGPTSpec.name,
+    {
+      description: importChatGPTSpec.description,
+    },
+    async (args) => {
+      const summary = await handleImportChatGPT(store, args);
+      return asResult(summary);
+    },
+  );
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+
+  const shutdown = async () => {
+    logger.info("shutdown", {});
+    for (const close of activeWatchers.splice(0, activeWatchers.length)) {
+      try {
+        await close();
+      } catch (err) {
+        logger.warn("watch-close-error", { err: err instanceof Error ? err.message : String(err) });
+      }
+    }
+    await server.close();
+    process.exit(0);
+  };
+
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
+
+  logger.info("mcp-server-started", { transport: "stdio" });
 }
 
 main().catch((err) => {
-  log('error', 'startup-failed', { err: String(err) });
+  logger.error("server-crash", { err: err instanceof Error ? err.message : String(err) });
   process.exit(1);
 });

--- a/src/store/keyword.ts
+++ b/src/store/keyword.ts
@@ -1,0 +1,60 @@
+import { Document, type DocumentValue, type EnrichedDocumentSearchResults } from "flexsearch";
+import { ChunkKind } from "../types.js";
+
+type KeywordDocument = {
+  id: string;
+  text: string;
+  tags: string[];
+  type: ChunkKind;
+  [key: string]: DocumentValue | DocumentValue[];
+};
+
+interface KeywordScore {
+  id: string;
+  rank: number;
+}
+
+export class KeywordStore {
+  private index: Document<KeywordDocument>;
+
+  constructor() {
+    this.index = new Document<KeywordDocument>({
+      document: {
+        id: "id",
+        store: true,
+        index: ["text", "tags"],
+      },
+    });
+  }
+
+  upsert(doc: KeywordDocument) {
+    this.index.remove(doc.id);
+    this.index.add(doc.id, doc);
+  }
+
+  remove(id: string) {
+    this.index.remove(id);
+  }
+
+  search(query: string, limit: number, types?: ChunkKind[]): KeywordScore[] {
+    const results = this.index.search(query, {
+      limit,
+      enrich: true,
+    }) as EnrichedDocumentSearchResults<KeywordDocument>;
+    const seen = new Set<string>();
+    const scores: KeywordScore[] = [];
+    let rank = 0;
+    for (const field of results) {
+      for (const result of field.result) {
+        const doc = result.doc;
+        if (!doc) continue;
+        if (types && !types.includes(doc.type)) continue;
+        if (seen.has(doc.id)) continue;
+        seen.add(doc.id);
+        scores.push({ id: doc.id, rank });
+        rank += 1;
+      }
+    }
+    return scores.slice(0, limit);
+  }
+}

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,0 +1,445 @@
+import { promises as fs } from "fs";
+import path from "path";
+import fg from "fast-glob";
+import chokidar from "chokidar";
+import { AppConfig } from "../config.js";
+import {
+  Chunk,
+  ChunkKind,
+  DocumentResult,
+  IndexFileResult,
+  Manifest,
+  ReindexSummary,
+  SearchOptions,
+  SearchResult,
+  StoreStats,
+} from "../types.js";
+import { FlatVectorStore } from "./vector-flat.js";
+import { KeywordStore } from "./keyword.js";
+import { computeChunkHash } from "../pipeline/chunk.js";
+import { embedText } from "../pipeline/embed.js";
+import { buildCitation } from "../utils/cite.js";
+import { logger } from "../utils/logger.js";
+import { nowIso } from "../utils/time.js";
+import { indexPdf } from "../indexers/pdf.js";
+import { indexMarkdown } from "../indexers/markdown.js";
+import { indexText } from "../indexers/text.js";
+import { indexWord } from "../indexers/word.js";
+import { indexPages } from "../indexers/pages.js";
+
+interface DocumentCache {
+  path: string;
+  type: ChunkKind;
+  fullText?: string;
+  pages?: string[];
+  partial?: boolean;
+}
+
+const MANIFEST_VERSION = 1;
+
+function createEmptyManifest(): Manifest {
+  const now = nowIso();
+  return {
+    version: MANIFEST_VERSION,
+    createdAt: now,
+    updatedAt: now,
+    files: {},
+    chunks: {},
+  };
+}
+
+function normalizeRel(filePath: string): string {
+  const abs = path.resolve(filePath);
+  return path.relative(process.cwd(), abs);
+}
+
+function extname(filePath: string): string {
+  return path.extname(filePath).toLowerCase();
+}
+
+function getFirstChunkType(chunks: Chunk[]): ChunkKind {
+  if (chunks.length === 0) {
+    return "text";
+  }
+  return chunks[0].type;
+}
+
+export class ResearchStore {
+  private manifest: Manifest = createEmptyManifest();
+  private vectorStore!: FlatVectorStore;
+  private keywordStore = new KeywordStore();
+  private readonly manifestPath: string;
+  private readonly docDir: string;
+  private initialized = false;
+
+  constructor(private config: AppConfig) {
+    const dataDir = path.resolve(process.cwd(), config.out.dataDir);
+    this.manifestPath = path.join(dataDir, "manifest.json");
+    this.docDir = path.join(dataDir, "docs");
+  }
+
+  async ready() {
+    await this.ensureInitialized();
+  }
+
+  getRoots(): string[] {
+    return [...this.config.roots.roots];
+  }
+
+  private async ensureInitialized() {
+    if (this.initialized) return;
+    await fs.mkdir(path.dirname(this.manifestPath), { recursive: true });
+    await fs.mkdir(this.docDir, { recursive: true });
+    await this.loadManifest();
+    this.vectorStore = await FlatVectorStore.load(path.dirname(this.manifestPath));
+    for (const chunk of Object.values(this.manifest.chunks)) {
+      this.keywordStore.upsert({ id: chunk.id, text: chunk.text, tags: chunk.tags ?? [], type: chunk.type });
+    }
+    this.initialized = true;
+  }
+
+  private async loadManifest() {
+    try {
+      const raw = await fs.readFile(this.manifestPath, "utf8");
+      const parsed = JSON.parse(raw) as Manifest;
+      if (parsed.version === MANIFEST_VERSION) {
+        this.manifest = parsed;
+        return;
+      }
+    } catch {}
+    this.manifest = createEmptyManifest();
+    await this.persistManifest();
+  }
+
+  private async persistManifest() {
+    this.manifest.updatedAt = nowIso();
+    await fs.writeFile(this.manifestPath, JSON.stringify(this.manifest, null, 2), "utf8");
+  }
+
+  private shouldInclude(filePath: string): boolean {
+    const ext = extname(filePath);
+    return this.config.roots.include.includes(ext);
+  }
+
+  private pickIndexer(ext: string) {
+    switch (ext) {
+      case ".pdf":
+        return (abs: string, mtime: number) => indexPdf(abs, mtime, this.chunkOptions(), this.config.index);
+      case ".md":
+      case ".markdown":
+        return (abs: string, mtime: number) => indexMarkdown(abs, mtime, this.chunkOptions());
+      case ".txt":
+        return (abs: string, mtime: number) => indexText(abs, mtime, this.chunkOptions());
+      case ".docx":
+        return (abs: string, mtime: number) => indexWord(abs, mtime, this.chunkOptions());
+      case ".pages":
+        return (abs: string, mtime: number) => indexPages(abs, mtime, this.chunkOptions());
+      default:
+        return null;
+    }
+  }
+
+  private chunkOptions() {
+    return { chunkSize: this.config.index.chunkSize, chunkOverlap: this.config.index.chunkOverlap };
+  }
+
+  private async writeDocumentCache(entry: DocumentCache, docPath: string) {
+    await fs.writeFile(docPath, JSON.stringify(entry), "utf8");
+  }
+
+  async reindex(paths?: string[]): Promise<ReindexSummary> {
+    await this.ensureInitialized();
+    const summary: ReindexSummary = { indexed: 0, updated: 0, skipped: 0, removed: 0 };
+    const input = paths && paths.length > 0 ? paths : this.config.roots.roots;
+    const files: string[] = [];
+    for (const entry of input) {
+      const absEntry = path.resolve(entry);
+      try {
+        const stat = await fs.stat(absEntry);
+        if (stat.isDirectory()) {
+          const pattern = path.join(absEntry, "**/*");
+          const dirFiles = await fg(pattern, {
+            onlyFiles: true,
+            ignore: this.config.roots.exclude,
+            dot: false,
+          });
+          files.push(...dirFiles);
+        } else if (stat.isFile()) {
+          files.push(absEntry);
+        }
+      } catch (err) {
+        logger.warn("path-skipped", { entry, err: (err as Error).message });
+      }
+    }
+    const seen = new Set<string>();
+
+    for (const absFile of files) {
+      const rel = normalizeRel(absFile);
+      seen.add(rel);
+      if (!this.shouldInclude(rel)) {
+        summary.skipped += 1;
+        continue;
+      }
+      const indexer = this.pickIndexer(extname(rel));
+      if (!indexer) {
+        summary.skipped += 1;
+        continue;
+      }
+      const stat = await fs.stat(absFile);
+      if (this.config.index.maxFileSizeMB) {
+        const maxBytes = this.config.index.maxFileSizeMB * 1024 * 1024;
+        if (stat.size > maxBytes) {
+          logger.warn("file-skipped-too-large", { path: rel, size: stat.size });
+          summary.skipped += 1;
+          continue;
+        }
+      }
+      const existing = this.manifest.files[rel];
+      if (existing && existing.mtime === stat.mtimeMs && existing.size === stat.size) {
+        summary.skipped += 1;
+        continue;
+      }
+
+      let result: IndexFileResult;
+      try {
+        result = await indexer(absFile, stat.mtimeMs);
+      } catch (err) {
+        logger.error("indexing-failed", { path: rel, err: (err as Error).message });
+        summary.skipped += 1;
+        continue;
+      }
+
+      const chunkIds: string[] = [];
+      for (const chunk of result.chunks) {
+        chunk.path = rel;
+        chunk.mtime = stat.mtimeMs;
+        chunk.partial = Boolean(chunk.partial || result.partial);
+        const hash = computeChunkHash(chunk);
+        this.keywordStore.upsert({ id: chunk.id, text: chunk.text, tags: chunk.tags ?? [], type: chunk.type });
+        const vector = await embedText(chunk.text, this.config.index.model);
+        this.vectorStore.upsert(chunk.id, vector);
+        this.manifest.chunks[chunk.id] = { ...chunk, hash };
+        chunkIds.push(chunk.id);
+      }
+
+      if (existing) {
+        if (existing.docPath) {
+          const prevDoc = path.join(this.docDir, existing.docPath);
+          if (result.fileHash && existing.docPath !== `${result.fileHash}.json`) {
+            try {
+              await fs.unlink(prevDoc);
+            } catch {}
+          }
+        }
+        for (const id of existing.chunkIds) {
+          if (!chunkIds.includes(id)) {
+            delete this.manifest.chunks[id];
+            this.keywordStore.remove(id);
+            this.vectorStore.delete(id);
+          }
+        }
+        summary.updated += 1;
+      } else {
+        summary.indexed += 1;
+      }
+
+      const fileHash = result.fileHash ?? `${Buffer.from(rel).toString("base64url")}-${stat.mtimeMs}`;
+      const docFilename = `${fileHash}.json`;
+      const docPath = path.join(this.docDir, docFilename);
+      await this.writeDocumentCache({
+        path: rel,
+        type: getFirstChunkType(result.chunks),
+        fullText: result.fullText,
+        pages: result.pages,
+        partial: result.partial,
+      }, docPath);
+
+      this.manifest.files[rel] = {
+        path: rel,
+        type: getFirstChunkType(result.chunks),
+        size: stat.size,
+        mtime: stat.mtimeMs,
+        hash: fileHash,
+        chunkIds,
+        partial: result.partial,
+        pages: result.pages?.length,
+        docPath: docFilename,
+      };
+    }
+
+    if (!paths || paths.length === 0) {
+      for (const existing of Object.keys(this.manifest.files)) {
+        if (!seen.has(existing)) {
+          await this.removeFile(existing);
+          summary.removed += 1;
+        }
+      }
+    }
+
+    await this.vectorStore.persist();
+    await this.persistManifest();
+    return summary;
+  }
+
+  private async removeFile(rel: string) {
+    const entry = this.manifest.files[rel];
+    if (!entry) return;
+    for (const id of entry.chunkIds) {
+      delete this.manifest.chunks[id];
+      this.keywordStore.remove(id);
+      this.vectorStore.delete(id);
+    }
+    if (entry.docPath) {
+      const docPath = path.join(this.docDir, entry.docPath);
+      try {
+        await fs.unlink(docPath);
+      } catch {}
+    }
+    delete this.manifest.files[rel];
+  }
+
+  async search(query: string, options: SearchOptions): Promise<SearchResult[]> {
+    await this.ensureInitialized();
+    const alpha = Math.min(Math.max(options.alpha, 0), 1);
+    const denseLimit = Math.max(options.k * 4, 32);
+    const vector = await embedText(query, this.config.index.model);
+    const dense = this.vectorStore.search(vector, denseLimit);
+    const keyword = this.keywordStore.search(query, denseLimit, options.filters?.type);
+    const combined = new Map<string, number>();
+    const typeFilter = options.filters?.type;
+
+    for (const hit of dense) {
+      const chunk = this.manifest.chunks[hit.id];
+      if (!chunk) continue;
+      if (typeFilter && !typeFilter.includes(chunk.type)) continue;
+      const normalized = (hit.score + 1) / 2;
+      combined.set(hit.id, (combined.get(hit.id) ?? 0) + alpha * normalized);
+    }
+
+    keyword.forEach((hit) => {
+      const chunk = this.manifest.chunks[hit.id];
+      if (!chunk) return;
+      const keywordScore = 1 / (1 + hit.rank);
+      combined.set(hit.id, (combined.get(hit.id) ?? 0) + (1 - alpha) * keywordScore);
+    });
+
+    const ranked = Array.from(combined.entries())
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, options.k);
+
+    return ranked
+      .map(([id, score]) => {
+        const chunk = this.manifest.chunks[id];
+        if (!chunk) return null;
+        const text = chunk.text.length > 600 ? `${chunk.text.slice(0, 600)}…` : chunk.text;
+        return {
+          chunkId: id,
+          score,
+          text,
+          citation: buildCitation(chunk),
+        };
+      })
+      .filter((value): value is SearchResult => value !== null);
+  }
+
+  async getDocument(targetPath: string, page?: number): Promise<DocumentResult> {
+    await this.ensureInitialized();
+    const rel = normalizeRel(targetPath);
+    const entry = this.manifest.files[rel];
+    if (!entry) {
+      throw new Error(`Path not indexed: ${targetPath}`);
+    }
+    const docPath = entry.docPath ? path.join(this.docDir, entry.docPath) : null;
+    let cache: DocumentCache | null = null;
+    if (docPath) {
+      try {
+        const raw = await fs.readFile(docPath, "utf8");
+        cache = JSON.parse(raw) as DocumentCache;
+      } catch {}
+    }
+    if (page != null && cache?.pages) {
+      const text = cache.pages[page - 1] ?? "";
+      return { path: rel, page, text, partial: cache.partial, type: entry.type };
+    }
+    const text = cache?.fullText ?? cache?.pages?.join("\n\n") ?? "";
+    return { path: rel, text, partial: cache?.partial, type: entry.type };
+  }
+
+  async stats(): Promise<StoreStats> {
+    await this.ensureInitialized();
+    const byType: StoreStats["byType"] = {
+      pdf: 0,
+      markdown: 0,
+      text: 0,
+      word: 0,
+      pages: 0,
+    } as any;
+    let totalLen = 0;
+    let chunks = 0;
+    for (const chunk of Object.values(this.manifest.chunks)) {
+      byType[chunk.type] = (byType[chunk.type] ?? 0) + 1;
+      totalLen += chunk.text.length;
+      chunks += 1;
+    }
+    const avgChunkLen = chunks === 0 ? 0 : Math.round(totalLen / chunks);
+    return {
+      files: Object.keys(this.manifest.files).length,
+      chunks,
+      byType,
+      avgChunkLen,
+      embeddingsCached: this.vectorStore.size(),
+      lastIndexedAt: this.manifest.updatedAt,
+    };
+  }
+
+  async watch(paths: string[], handler: (event: { event: string; path: string }) => void) {
+    await this.ensureInitialized();
+    const watcher = chokidar.watch(paths.length ? paths : this.config.roots.roots, {
+      ignoreInitial: true,
+      ignored: this.config.roots.exclude,
+    });
+
+    await new Promise<void>((resolve) => {
+      watcher.once("ready", () => resolve());
+    });
+
+    const queue: Promise<unknown>[] = [];
+    const enqueue = (promise: Promise<unknown>) => {
+      queue.push(promise.finally(() => {
+        const index = queue.indexOf(promise);
+        if (index >= 0) queue.splice(index, 1);
+      }));
+    };
+
+    watcher.on("add", (filePath) => {
+      handler({ event: "add", path: normalizeRel(filePath) });
+      enqueue(this.reindex([filePath]));
+    });
+    watcher.on("change", (filePath) => {
+      handler({ event: "change", path: normalizeRel(filePath) });
+      enqueue(this.reindex([filePath]));
+    });
+    watcher.on("unlink", (filePath) => {
+      handler({ event: "unlink", path: normalizeRel(filePath) });
+      enqueue(
+        (async () => {
+          await this.ensureInitialized();
+          await this.removeFile(normalizeRel(filePath));
+          await this.vectorStore.persist();
+          await this.persistManifest();
+        })(),
+      );
+    });
+
+    return async () => {
+      await watcher.close();
+      await Promise.allSettled(queue);
+    };
+  }
+}
+
+export async function createStore(config: AppConfig): Promise<ResearchStore> {
+  const store = new ResearchStore(config);
+  await store.ready();
+  return store;
+}

--- a/src/store/vector-flat.ts
+++ b/src/store/vector-flat.ts
@@ -1,0 +1,108 @@
+import { promises as fs } from "fs";
+import path from "path";
+import { logger } from "../utils/logger.js";
+
+export interface VectorScore {
+  id: string;
+  score: number;
+}
+
+interface StoredVector {
+  vector: Float32Array;
+  norm: number;
+}
+
+export class FlatVectorStore {
+  private vectors = new Map<string, StoredVector>();
+  private dirty = false;
+
+  constructor(private baseDir: string) {}
+
+  static async load(baseDir: string): Promise<FlatVectorStore> {
+    const store = new FlatVectorStore(baseDir);
+    await store.load();
+    return store;
+  }
+
+  private async load() {
+    await fs.mkdir(this.baseDir, { recursive: true });
+    const manifestPath = path.join(this.baseDir, "vectors.json");
+    const binPath = path.join(this.baseDir, "vectors.bin");
+    try {
+      const manifestRaw = await fs.readFile(manifestPath, "utf8");
+      const manifest = JSON.parse(manifestRaw) as Record<string, { offset: number; length: number; norm: number }>;
+      const bin = await fs.readFile(binPath);
+      const buffer = new Float32Array(bin.buffer, bin.byteOffset, bin.byteLength / Float32Array.BYTES_PER_ELEMENT);
+      for (const [id, entry] of Object.entries(manifest)) {
+        const { offset, length, norm } = entry;
+        const slice = buffer.subarray(offset, offset + length);
+        this.vectors.set(id, { vector: Float32Array.from(slice), norm });
+      }
+      logger.info("vector-flat-loaded", { count: this.vectors.size });
+    } catch (err) {
+      logger.info("vector-flat-new", { baseDir: this.baseDir, err: (err as Error).message });
+    }
+  }
+
+  private computeNorm(vector: Float32Array): number {
+    let sum = 0;
+    for (let i = 0; i < vector.length; i += 1) {
+      sum += vector[i] * vector[i];
+    }
+    return Math.sqrt(sum);
+  }
+
+  upsert(id: string, vector: Float32Array) {
+    const norm = this.computeNorm(vector);
+    this.vectors.set(id, { vector, norm });
+    this.dirty = true;
+  }
+
+  delete(id: string) {
+    if (this.vectors.delete(id)) {
+      this.dirty = true;
+    }
+  }
+
+  async persist() {
+    if (!this.dirty) return;
+    const manifestPath = path.join(this.baseDir, "vectors.json");
+    const binPath = path.join(this.baseDir, "vectors.bin");
+    const entries = Array.from(this.vectors.entries());
+    const manifest: Record<string, { offset: number; length: number; norm: number }> = {};
+    let offset = 0;
+    const buffers: Buffer[] = [];
+    for (const [id, stored] of entries) {
+      manifest[id] = { offset, length: stored.vector.length, norm: stored.norm };
+      const buf = Buffer.from(stored.vector.buffer, stored.vector.byteOffset, stored.vector.byteLength);
+      buffers.push(Buffer.from(buf));
+      offset += stored.vector.length;
+    }
+    await fs.writeFile(binPath, Buffer.concat(buffers));
+    await fs.writeFile(manifestPath, JSON.stringify(manifest, null, 2), "utf8");
+    this.dirty = false;
+  }
+
+  search(query: Float32Array, k: number): VectorScore[] {
+    const norm = this.computeNorm(query);
+    if (!norm) return [];
+    const scores: VectorScore[] = [];
+    for (const [id, stored] of this.vectors.entries()) {
+      if (!stored.norm) continue;
+      let dot = 0;
+      const vec = stored.vector;
+      for (let i = 0; i < vec.length; i += 1) {
+        dot += vec[i] * query[i];
+      }
+      const score = dot / (norm * stored.norm);
+      scores.push({ id, score });
+    }
+    return scores
+      .sort((a, b) => b.score - a.score)
+      .slice(0, k);
+  }
+
+  size() {
+    return this.vectors.size;
+  }
+}

--- a/src/store/vector-sqlitevss.ts
+++ b/src/store/vector-sqlitevss.ts
@@ -1,0 +1,24 @@
+import { logger } from "../utils/logger.js";
+
+export interface VectorScore {
+  id: string;
+  score: number;
+}
+
+export interface SQLiteVectorStoreLike {
+  upsert(id: string, vector: Float32Array): Promise<void>;
+  delete(id: string): Promise<void>;
+  search(query: Float32Array, k: number): Promise<VectorScore[]>;
+  close(): Promise<void>;
+}
+
+export async function createSQLiteVectorStore(_baseDir: string): Promise<SQLiteVectorStoreLike | null> {
+  try {
+    await import("sqlite3");
+  } catch (err) {
+    logger.info("sqlite3-missing", { err: (err as Error).message });
+    return null;
+  }
+  logger.warn("sqlite-vss-fallback", { reason: "extension-not-implemented" });
+  return null;
+}

--- a/src/tools/getDoc.ts
+++ b/src/tools/getDoc.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+import { ResearchStore } from "../store/store.js";
+
+const InputSchema = z.object({
+  path: z.string().min(1),
+  page: z.number().int().min(1).optional(),
+});
+
+export async function handleGetDoc(store: ResearchStore, input: unknown) {
+  const parsed = InputSchema.parse(input);
+  const doc = await store.getDocument(parsed.path, parsed.page);
+  return doc;
+}
+
+export const getDocSpec = {
+  name: "get_doc",
+  description: "Return the full text for a file or a specific page.",
+  inputSchema: InputSchema,
+};

--- a/src/tools/importChatGPT.ts
+++ b/src/tools/importChatGPT.ts
@@ -1,0 +1,56 @@
+import path from "path";
+import { promises as fs } from "fs";
+import { z } from "zod";
+import { ResearchStore } from "../store/store.js";
+import { convertChatGPTExport } from "../chatgpt/convert.js";
+
+const InputSchema = z.object({
+  exportPath: z.string().min(1),
+  outDir: z.string().min(1).default("./docs/chatgpt-export-md"),
+});
+
+function resolveOutDir(store: ResearchStore, outDir: string) {
+  const repoRoot = process.cwd();
+  const abs = path.resolve(outDir);
+  const rel = path.relative(repoRoot, abs);
+  const allowedTop = new Set(["docs", "public", "fixtures", ".mcp-nn"]);
+
+  if (!rel.startsWith("..") && !path.isAbsolute(rel)) {
+    const top = rel.split(path.sep)[0] ?? "";
+    if (!allowedTop.has(top)) {
+      throw new Error(`Output directory must be under docs/public/fixtures/.mcp-nn: ${outDir}`);
+    }
+    return abs;
+  }
+
+  const allowedRoots = store.getRoots().map((root) => path.resolve(root));
+  const matchesRoot = allowedRoots.some((root) => abs === root || abs.startsWith(`${root}${path.sep}`));
+  if (!matchesRoot) {
+    throw new Error(`Output directory must be inside the repository or configured roots: ${outDir}`);
+  }
+  return abs;
+}
+
+async function ensureDir(dir: string) {
+  await fs.mkdir(dir, { recursive: true });
+}
+
+export async function handleImportChatGPT(store: ResearchStore, input: unknown) {
+  const parsed = InputSchema.parse(input);
+  const outDirAbs = resolveOutDir(store, parsed.outDir);
+  await ensureDir(outDirAbs);
+  const event = await convertChatGPTExport(path.resolve(parsed.exportPath), outDirAbs);
+  await store.reindex([outDirAbs]);
+  return {
+    exportPath: parsed.exportPath,
+    outDir: outDirAbs,
+    conversations: event.conversations,
+    filesWritten: event.filesWritten,
+  };
+}
+
+export const importChatGPTSpec = {
+  name: "import_chatgpt_export",
+  description: "Convert a ChatGPT export archive into Markdown and reindex the output directory.",
+  inputSchema: InputSchema,
+};

--- a/src/tools/reindex.ts
+++ b/src/tools/reindex.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+import { ResearchStore } from "../store/store.js";
+
+const InputSchema = z.object({
+  paths: z.array(z.string().min(1)).optional(),
+});
+
+export async function handleReindex(store: ResearchStore, input: unknown) {
+  const parsed = input ? InputSchema.parse(input) : { paths: undefined };
+  const summary = await store.reindex(parsed.paths);
+  return summary;
+}
+
+export const reindexSpec = {
+  name: "reindex",
+  description: "Rebuild the index for one or more paths.",
+  inputSchema: InputSchema,
+};

--- a/src/tools/searchLocal.ts
+++ b/src/tools/searchLocal.ts
@@ -1,0 +1,36 @@
+import { z } from "zod";
+import { ResearchStore } from "../store/store.js";
+
+const FiltersSchema = z
+  .object({
+    type: z.array(z.enum(["pdf", "markdown", "text", "word", "pages"])).optional(),
+  })
+  .optional();
+
+const InputSchema = z.object({
+  query: z.string().min(1),
+  k: z.number().int().min(1).max(32).default(8),
+  alpha: z.number().min(0).max(1).default(0.65),
+  filters: FiltersSchema,
+});
+
+export type SearchLocalInput = z.infer<typeof InputSchema>;
+
+export async function handleSearchLocal(store: ResearchStore, input: unknown) {
+  const parsed = InputSchema.parse(input);
+  const results = await store.search(parsed.query, {
+    k: parsed.k,
+    alpha: parsed.alpha,
+    filters: parsed.filters,
+  });
+  return {
+    query: parsed.query,
+    results,
+  };
+}
+
+export const searchLocalSpec = {
+  name: "search_local",
+  description: "Hybrid search across indexed local documents.",
+  inputSchema: InputSchema,
+};

--- a/src/tools/stats.ts
+++ b/src/tools/stats.ts
@@ -1,0 +1,11 @@
+import { ResearchStore } from "../store/store.js";
+
+export async function handleStats(store: ResearchStore) {
+  const stats = await store.stats();
+  return stats;
+}
+
+export const statsSpec = {
+  name: "stats",
+  description: "Return summary statistics about the index.",
+};

--- a/src/tools/watch.ts
+++ b/src/tools/watch.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+import { ResearchStore } from "../store/store.js";
+
+const InputSchema = z.object({
+  paths: z.array(z.string().min(1)).optional(),
+});
+
+export type WatchEmitter = (event: { event: string; path: string }) => void;
+
+export async function handleWatch(store: ResearchStore, input: unknown, emit: WatchEmitter) {
+  const parsed = input ? InputSchema.parse(input) : { paths: undefined };
+  const close = await store.watch(parsed.paths ?? [], emit);
+  return {
+    result: { watching: parsed.paths ?? store.getRoots() },
+    close,
+  };
+}
+
+export const watchSpec = {
+  name: "watch",
+  description: "Watch paths for changes and automatically reindex.",
+  inputSchema: InputSchema,
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,100 @@
+export type ChunkKind = "pdf" | "markdown" | "text" | "word" | "pages";
+
+export interface Chunk {
+  id: string;
+  path: string;
+  type: ChunkKind;
+  page?: number;
+  offsetStart?: number;
+  offsetEnd?: number;
+  text: string;
+  tokens?: number;
+  tags?: string[];
+  partial?: boolean;
+  mtime: number;
+}
+
+export interface ChunkWithEmbedding extends Chunk {
+  vector?: Float32Array;
+  hash: string;
+}
+
+export interface Citation {
+  filePath: string;
+  page?: number;
+  startChar?: number;
+  endChar?: number;
+  snippet: string;
+}
+
+export interface SearchResult {
+  chunkId: string;
+  score: number;
+  text: string;
+  citation: Citation;
+}
+
+export interface FileManifestEntry {
+  path: string;
+  type: ChunkKind;
+  size: number;
+  mtime: number;
+  hash: string;
+  chunkIds: string[];
+  partial?: boolean;
+  pages?: number;
+  docPath?: string;
+}
+
+export interface StoredChunk extends Chunk {
+  hash: string;
+}
+
+export interface Manifest {
+  version: number;
+  createdAt: string;
+  updatedAt: string;
+  files: Record<string, FileManifestEntry>;
+  chunks: Record<string, StoredChunk>;
+}
+
+export interface SearchOptions {
+  k: number;
+  alpha: number;
+  filters?: {
+    type?: ChunkKind[];
+  };
+}
+
+export interface ReindexSummary {
+  indexed: number;
+  updated: number;
+  skipped: number;
+  removed: number;
+}
+
+export interface StoreStats {
+  files: number;
+  chunks: number;
+  byType: Record<ChunkKind, number>;
+  avgChunkLen: number;
+  embeddingsCached: number;
+  lastIndexedAt?: string;
+}
+
+export interface DocumentResult {
+  path: string;
+  page?: number;
+  text: string;
+  partial?: boolean;
+  type: ChunkKind;
+}
+
+export interface IndexFileResult {
+  chunks: Chunk[];
+  pages?: string[];
+  fullText?: string;
+  partial?: boolean;
+  tags?: string[];
+  fileHash?: string;
+}

--- a/src/types/pdf-parse.d.ts
+++ b/src/types/pdf-parse.d.ts
@@ -1,0 +1,5 @@
+declare module "pdf-parse";
+declare module "pdf-parse/lib/pdf-parse.js" {
+  const pdfParse: any;
+  export default pdfParse;
+}

--- a/src/utils/cite.ts
+++ b/src/utils/cite.ts
@@ -1,0 +1,30 @@
+import { Chunk, Citation } from "../types.js";
+
+const DEFAULT_SNIPPET = 220;
+
+function normalizeWhitespace(text: string) {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+export function buildSnippet(text: string, start?: number, end?: number, span = DEFAULT_SNIPPET): string {
+  const clean = normalizeWhitespace(text);
+  if (!clean) return "";
+  if (start == null || end == null) {
+    return clean.length > span ? `${clean.slice(0, span)}…` : clean;
+  }
+  const clampedStart = Math.max(0, start - Math.floor(span / 2));
+  const clampedEnd = Math.min(clean.length, end + Math.floor(span / 2));
+  const prefix = clampedStart > 0 ? "…" : "";
+  const suffix = clampedEnd < clean.length ? "…" : "";
+  return `${prefix}${clean.slice(clampedStart, clampedEnd)}${suffix}`;
+}
+
+export function buildCitation(chunk: Chunk): Citation {
+  return {
+    filePath: chunk.path,
+    page: chunk.page,
+    startChar: chunk.offsetStart,
+    endChar: chunk.offsetEnd,
+    snippet: buildSnippet(chunk.text, chunk.offsetStart, chunk.offsetEnd),
+  };
+}

--- a/src/utils/fs-guard.ts
+++ b/src/utils/fs-guard.ts
@@ -1,0 +1,41 @@
+import { promises as fs } from "fs";
+import path from "path";
+import { RootsConfig } from "../config.js";
+
+export async function realpathSafe(target: string): Promise<string> {
+  const abs = path.resolve(target);
+  const real = await fs.realpath(abs);
+  return real;
+}
+
+export function withinRoots(real: string, roots: string[]): boolean {
+  return roots.some((root) => {
+    const resolvedRoot = path.resolve(root);
+    const relative = path.relative(resolvedRoot, real);
+    return relative && !relative.startsWith("..") && !path.isAbsolute(relative);
+  });
+}
+
+export async function ensureWithinRoots(target: string, config: RootsConfig): Promise<string> {
+  const real = await realpathSafe(target);
+  if (!withinRoots(real, config.roots)) {
+    throw new Error(`Path ${target} is outside configured roots`);
+  }
+  return real;
+}
+
+export async function safeStat(target: string, config: RootsConfig) {
+  const real = await ensureWithinRoots(target, config);
+  return { real, stat: await fs.stat(real) };
+}
+
+export function matchesInclude(file: string, include: string[]): boolean {
+  return include.some((ext) => file.toLowerCase().endsWith(ext.toLowerCase()));
+}
+
+export function matchesExclude(file: string, exclude: string[]): boolean {
+  return exclude.some((pattern) => {
+    const normalized = pattern.replace(/\*\*\//g, "");
+    return file.includes(normalized.replace(/\*/g, ""));
+  });
+}

--- a/src/utils/hash.ts
+++ b/src/utils/hash.ts
@@ -1,0 +1,21 @@
+import crypto from "crypto";
+import { v5 as uuidv5 } from "uuid";
+
+const CHUNK_NAMESPACE = uuidv5("chunk.mcp-nn", uuidv5.URL);
+
+export function hashContent(content: string): string {
+  return crypto.createHash("sha1").update(content).digest("hex");
+}
+
+export function hashBuffer(buffer: Buffer): string {
+  return crypto.createHash("sha1").update(buffer).digest("hex");
+}
+
+export function createChunkId(path: string, page: number | undefined, start: number | undefined, end: number | undefined): string {
+  const raw = `${path}|${page ?? ""}|${start ?? 0}|${end ?? 0}`;
+  return uuidv5(raw, CHUNK_NAMESPACE);
+}
+
+export function hashChunkInput(path: string, mtime: number, content: string): string {
+  return crypto.createHash("sha1").update(path).update(String(mtime)).update(content).digest("hex");
+}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,39 @@
+export type LogLevel = "debug" | "info" | "warn" | "error";
+
+const LEVELS: LogLevel[] = ["debug", "info", "warn", "error"];
+const LEVEL = process.env.LOG_LEVEL as LogLevel | undefined;
+const activeLevel = LEVEL && LEVELS.includes(LEVEL) ? LEVEL : "info";
+
+const levelWeight = new Map<LogLevel, number>([
+  ["debug", 10],
+  ["info", 20],
+  ["warn", 30],
+  ["error", 40],
+]);
+
+function shouldLog(level: LogLevel) {
+  return (levelWeight.get(level) ?? 0) >= (levelWeight.get(activeLevel) ?? 0);
+}
+
+export interface LogMeta {
+  [key: string]: unknown;
+}
+
+export function log(level: LogLevel, msg: string, meta: LogMeta = {}): void {
+  if (!shouldLog(level)) return;
+  const payload = {
+    level,
+    msg,
+    time: new Date().toISOString(),
+    pid: process.pid,
+    ...meta,
+  };
+  process.stdout.write(`${JSON.stringify(payload)}\n`);
+}
+
+export const logger = {
+  debug: (msg: string, meta?: LogMeta) => log("debug", msg, meta),
+  info: (msg: string, meta?: LogMeta) => log("info", msg, meta),
+  warn: (msg: string, meta?: LogMeta) => log("warn", msg, meta),
+  error: (msg: string, meta?: LogMeta) => log("error", msg, meta),
+};

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,0 +1,7 @@
+export function nowIso(): string {
+  return new Date().toISOString();
+}
+
+export function durationMs(start: number): number {
+  return Date.now() - start;
+}

--- a/tests/chatgpt.convert.test.ts
+++ b/tests/chatgpt.convert.test.ts
@@ -1,0 +1,17 @@
+import { promises as fs } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+import { describe, expect, test } from "vitest";
+import { convertChatGPTExport } from "../src/chatgpt/convert.js";
+
+describe("chatgpt export converter", () => {
+  test("writes markdown files with metadata", async () => {
+    const outDir = await fs.mkdtemp(path.join(tmpdir(), "chatgpt-out-"));
+    const result = await convertChatGPTExport(path.join(process.cwd(), "fixtures", "chatgpt-export-sample"), outDir);
+    expect(result.filesWritten).toBeGreaterThan(0);
+    const files = await fs.readdir(outDir);
+    expect(files.some((f) => f.endsWith(".md"))).toBe(true);
+    const sample = await fs.readFile(path.join(outDir, files[0]), "utf8");
+    expect(sample).toContain("source: \"chatgpt-export\"");
+  });
+});

--- a/tests/chunk.test.ts
+++ b/tests/chunk.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "vitest";
+import { chunkSource, computeChunkHash } from "../src/pipeline/chunk.js";
+
+const options = { chunkSize: 50, chunkOverlap: 10 };
+
+describe("chunkSource", () => {
+  test("splits text into overlapping chunks", () => {
+    const text = Array.from({ length: 5 })
+      .map((_, idx) => `Paragraph ${idx + 1} line alpha bravo charlie delta echo.`)
+      .join("\n\n");
+    const chunks = chunkSource({ path: "doc.txt", type: "text", text, mtime: Date.now() }, options);
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.text.length).toBeLessThanOrEqual(options.chunkSize + 5);
+      expect(chunk.offsetStart).toBeLessThan((chunk.offsetEnd ?? 0) + 1);
+    }
+  });
+
+  test("produces stable hashes for identical chunks", () => {
+    const text = "alpha bravo charlie";
+    const [chunk] = chunkSource({ path: "doc.txt", type: "text", text, mtime: 100 }, options);
+    const hash1 = computeChunkHash(chunk);
+    const hash2 = computeChunkHash({ ...chunk });
+    expect(hash1).toEqual(hash2);
+  });
+});

--- a/tests/embed.test.ts
+++ b/tests/embed.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test, vi } from "vitest";
+
+vi.mock("@xenova/transformers", () => ({
+  pipeline: vi.fn(async () => async (text: string) => ({ data: [text.length, text.split(/\s+/).length] })),
+}));
+
+import { embedText, onModelStatus } from "../src/pipeline/embed.js";
+
+describe("embed pipeline", () => {
+  test("returns Float32Array vectors", async () => {
+    const vec = await embedText("alpha bravo", "fake-model");
+    expect(vec).toBeInstanceOf(Float32Array);
+    expect(vec.length).toBeGreaterThan(0);
+  });
+
+  test("invokes status callbacks", async () => {
+    const spy = vi.fn();
+    onModelStatus(spy);
+    await embedText("sample", "fake-model");
+    expect(spy).toHaveBeenCalledWith("loading");
+    expect(spy).toHaveBeenCalledWith("ready");
+  });
+});

--- a/tests/indexers.pages.test.ts
+++ b/tests/indexers.pages.test.ts
@@ -1,0 +1,21 @@
+import { promises as fs } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+import AdmZip from "adm-zip";
+import { describe, expect, test } from "vitest";
+import { indexPages } from "../src/indexers/pages.js";
+
+const chunkOptions = { chunkSize: 1200, chunkOverlap: 0 };
+
+describe("pages indexer", () => {
+  test("marks modern .pages bundles as partial", async () => {
+    const dir = await fs.mkdtemp(path.join(tmpdir(), "pages-test-"));
+    const filePath = path.join(dir, "test.pages");
+    const zip = new AdmZip();
+    zip.addFile("Data/document.iwa", Buffer.from("stub"));
+    await fs.writeFile(filePath, zip.toBuffer());
+
+    const result = await indexPages(filePath, Date.now(), chunkOptions);
+    expect(result.partial).toBe(true);
+  });
+});

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -1,0 +1,72 @@
+import { promises as fs } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+import { afterAll, beforeAll, describe, expect, test, vi } from "vitest";
+
+vi.mock("../src/pipeline/embed", () => ({
+  embedText: vi.fn(async (text: string) => {
+    const length = text.length;
+    const words = text.split(/\s+/).length;
+    return new Float32Array([length, words, length + words]);
+  }),
+  onModelStatus: vi.fn(),
+}));
+
+import { ResearchStore } from "../src/store/store.js";
+import type { AppConfig } from "../src/config.js";
+
+const tmpRoots: string[] = [];
+
+afterAll(async () => {
+  await Promise.all(tmpRoots.map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+function buildConfig(root: string, dataDir: string): AppConfig {
+  return {
+    roots: {
+      roots: [root],
+      include: [".txt"],
+      exclude: [],
+    },
+    index: {
+      chunkSize: 1200,
+      chunkOverlap: 50,
+      ocrEnabled: false,
+      ocrTriggerMinChars: 100,
+      useSQLiteVSS: false,
+      model: "stub",
+      maxFileSizeMB: 10,
+      concurrency: 1,
+    },
+    out: {
+      dataDir,
+    },
+  };
+}
+
+describe("store hybrid search", () => {
+  let docsDir: string;
+  let dataDir: string;
+
+  beforeAll(async () => {
+    const base = await fs.mkdtemp(path.join(tmpdir(), "mcp-store-"));
+    docsDir = path.join(base, "docs");
+    dataDir = path.join(base, "data");
+    tmpRoots.push(base);
+    await fs.mkdir(docsDir, { recursive: true });
+    await fs.writeFile(path.join(docsDir, "antwerp.txt"), "Antwerp remains a primary entry point for cocaine shipments.");
+    await fs.writeFile(path.join(docsDir, "coffee.txt"), "Colombia exports coffee through Cartagena.");
+  });
+
+  test("returns ranked results", async () => {
+    const config = buildConfig(docsDir, dataDir);
+    const store = new ResearchStore(config);
+    await store.ready();
+    await store.reindex([docsDir]);
+
+    const results = await store.search("cocaine antwerp", { k: 5, alpha: 0.6 });
+    expect(results.length).toBeGreaterThan(0);
+    const top = results[0];
+    expect(top.citation.filePath).toContain("antwerp.txt");
+  });
+});

--- a/tests/store.fallback.test.ts
+++ b/tests/store.fallback.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, test } from "vitest";
+import { createSQLiteVectorStore } from "../src/store/vector-sqlitevss.js";
+
+describe("sqlite fallback", () => {
+  test("returns null when sqlite3 is unavailable", async () => {
+    const store = await createSQLiteVectorStore("./tmp");
+    expect(store).toBeNull();
+  });
+});

--- a/tests/tools.importChatGPT.test.ts
+++ b/tests/tools.importChatGPT.test.ts
@@ -1,0 +1,55 @@
+import { promises as fs } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+import { afterAll, describe, expect, test, vi } from "vitest";
+
+vi.mock("../src/pipeline/embed", () => ({
+  embedText: vi.fn(async (text: string) => new Float32Array([text.length || 1, 1])),
+  onModelStatus: vi.fn(),
+}));
+
+import { ResearchStore } from "../src/store/store.js";
+import type { AppConfig } from "../src/config.js";
+import { handleImportChatGPT } from "../src/tools/importChatGPT.js";
+
+const cleanupDirs: string[] = [];
+
+afterAll(async () => {
+  await Promise.all(cleanupDirs.map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("import_chatgpt_export tool", () => {
+  test("converts export and reindexes", async () => {
+    const base = await fs.mkdtemp(path.join(tmpdir(), "chatgpt-tool-"));
+    cleanupDirs.push(base);
+    const docsDir = path.join(base, "docs");
+    const dataDir = path.join(base, "data");
+    await fs.mkdir(docsDir, { recursive: true });
+    const config: AppConfig = {
+      roots: { roots: [docsDir], include: [".md"], exclude: [] },
+      index: {
+        chunkSize: 1200,
+        chunkOverlap: 50,
+        ocrEnabled: false,
+        ocrTriggerMinChars: 100,
+        useSQLiteVSS: false,
+        model: "stub",
+        maxFileSizeMB: 10,
+        concurrency: 1,
+      },
+      out: { dataDir },
+    };
+
+    const store = new ResearchStore(config);
+    await store.ready();
+
+    const summary = await handleImportChatGPT(store, {
+      exportPath: path.join(process.cwd(), "fixtures", "chatgpt-export-sample"),
+      outDir: path.join(docsDir, "chatgpt"),
+    });
+
+    expect(summary.filesWritten).toBeGreaterThan(0);
+    const results = await store.search("hello", { k: 1, alpha: 0.5 });
+    expect(results.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/watch.test.ts
+++ b/tests/watch.test.ts
@@ -1,0 +1,56 @@
+import { promises as fs } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+import { afterAll, describe, expect, test, vi } from "vitest";
+
+vi.mock("../src/pipeline/embed", () => ({
+  embedText: vi.fn(async (text: string) => new Float32Array([text.length || 1, 1, 1])),
+  onModelStatus: vi.fn(),
+}));
+
+import { ResearchStore } from "../src/store/store.js";
+import type { AppConfig } from "../src/config.js";
+
+const createdDirs: string[] = [];
+
+afterAll(async () => {
+  await Promise.all(createdDirs.map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("watch integration", () => {
+  test("emits events on file changes", async () => {
+    const base = await fs.mkdtemp(path.join(tmpdir(), "mcp-watch-"));
+    createdDirs.push(base);
+    const docsDir = path.join(base, "docs");
+    const dataDir = path.join(base, "data");
+    await fs.mkdir(docsDir, { recursive: true });
+
+    const config: AppConfig = {
+      roots: { roots: [docsDir], include: [".txt"], exclude: [] },
+      index: {
+        chunkSize: 1000,
+        chunkOverlap: 20,
+        ocrEnabled: false,
+        ocrTriggerMinChars: 100,
+        useSQLiteVSS: false,
+        model: "stub",
+        maxFileSizeMB: 10,
+        concurrency: 1,
+      },
+      out: { dataDir },
+    };
+
+    const store = new ResearchStore(config);
+    await store.ready();
+
+    const events: { event: string; path: string }[] = [];
+    const close = await store.watch([docsDir], (evt: { event: string; path: string }) => events.push(evt));
+
+    await fs.writeFile(path.join(docsDir, "note.txt"), "Initial content");
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    expect(events.some((evt) => evt.event === "add")).toBe(true);
+
+    await close();
+  }, 10_000);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ESNext",
+    "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "resolveJsonModule": true,
     "esModuleInterop": true,
@@ -10,6 +10,6 @@
     "strict": true,
     "types": ["node"]
   },
-  "include": ["src/**/*.ts"],
+  "include": ["src/**/*.ts", "tests/**/*.ts"],
   "ts-node": { "esm": true }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["tests/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Summary
- add an offline-first MCP server with configuration, indexers, hybrid search store, and CLI utilities
- implement ChatGPT export conversion tooling and import MCP endpoint for rapid ingestion
- document setup, configuration, and fixtures to validate the local indexing workflow

## Testing
- npm run typecheck
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce2b69f94c83279d381836b9fadcfc