### PR TITLE
Implement offline MCP indexing server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,198 @@
+# mcp-nn
+
+Offline MCP server for NarcoNations.org research. Index and search local PDFs, Markdown, TXT, Word (`.docx`), and Apple Pages (`.pages`) files with hybrid retrieval (dense embeddings + BM25) and precise citations. Everything runs locally—no network calls after the initial model download.
+
+---
+
+## Quickstart
+
+### Requirements
+- Node.js 20+
+- macOS, Linux, or Windows
+
+```bash
+# 1) Install dependencies
+npm install
+
+# 2) (Optional) Prefetch the local embedding model for offline use
+npm run models:download
+
+# 3) Index your research folders
+npm run index -- ./docs ./public/dossiers ./pdfs
+
+# 4) Start the MCP server (stdio transport)
+npm run dev
+```
+
+### Example MCP tool calls
+
+`search_local`
+```json
+{
+  "tool": "search_local",
+  "input": { "query": "Antwerp cocaine port", "k": 8, "alpha": 0.65 }
+}
+```
+
+`get_doc`
+```json
+{
+  "tool": "get_doc",
+  "input": { "path": "./docs/ports/antwerp.pdf", "page": 12 }
+}
+```
+
+---
+
+## ChatGPT → ZIP → Markdown → Index
+
+1. **Export chats from ChatGPT** (Profile → Settings → Data Controls → Export) and unzip locally.
+2. **Convert to Markdown**
+   ```bash
+   npm run chatgpt:to-md -- ~/Downloads/chatgpt-export
+   # → writes Markdown into ./docs/chatgpt-export-md
+   ```
+3. **Index the converted chats**
+   ```bash
+   npm run index -- ./docs/chatgpt-export-md
+   ```
+4. **Search from an MCP client**
+   ```json
+   { "tool": "search_local", "input": { "query": "Antwerp port", "k": 6 } }
+   ```
+
+Optional one-shot tool:
+```json
+{
+  "tool": "import_chatgpt_export",
+  "input": { "exportPath": "~/Downloads/chatgpt-export", "outDir": "./docs/chatgpt-export-md" }
+}
+```
+
+> ⚠️ Chat exports may contain sensitive data. Keep them local and within approved roots.
+
+---
+
+## Configuration
+
+Run the server once to materialize `.mcp-nn/config.json`, then tailor the defaults. Base values:
+
+```json
+{
+  "roots": {
+    "roots": ["./docs", "./public/dossiers", "./docs/chatgpt-export-md"],
+    "include": [".pdf", ".md", ".txt", ".docx", ".pages"],
+    "exclude": ["**/node_modules/**", ".git/**"]
+  },
+  "index": {
+    "chunkSize": 3500,
+    "chunkOverlap": 120,
+    "ocrEnabled": true,
+    "ocrTriggerMinChars": 100,
+    "useSQLiteVSS": false,
+    "model": "Xenova/all-MiniLM-L6-v2",
+    "maxFileSizeMB": 200,
+    "concurrency": 2,
+    "languages": ["eng"]
+  },
+  "out": { "dataDir": ".mcp-nn" }
+}
+```
+
+Environment overrides:
+- `MCP_NN_DATA_DIR` – relocate index storage.
+- `TRANSFORMERS_CACHE` – control embedding model cache directory.
+- `TRANSFORMERS_OFFLINE=1` – enforce offline model loads.
+
+---
+
+## File Types & Notes
+
+- **PDF** – Uses `pdf-parse`. Pages with scarce text trigger an OCR warning (Tesseract recommended); encrypted PDFs are skipped.
+- **Markdown** – `gray-matter` preserves front-matter (e.g., `tags`).
+- **TXT** – UTF‑8 normalized to NFKC with paragraph boundaries preserved.
+- **Word (`.docx`)** – Extracted via `mammoth` (clean text only).
+- **Pages (`.pages`)** – `adm-zip` + `fast-xml-parser`. Modern `.iwa` archives may yield partial results; warnings are emitted without aborting.
+
+---
+
+## Hybrid Retrieval
+
+1. **Dense vectors** from `@xenova/transformers` (`all-MiniLM-L6-v2`). Stored in a flat cosine index (`.mcp-nn/vectors.bin`).
+2. **Keyword BM25** via FlexSearch Document index.
+3. `search_local` mixes dense and keyword hits using `alpha` (default 0.65). Results include citations with file paths, page numbers, and character offsets.
+
+Embeddings are cached locally (`.mcp-nn/embeddings-cache.json`). You can force a lightweight deterministic fallback by setting `MCP_NN_EMBED_FAKE=1` (useful for tests).
+
+---
+
+## Tools Overview
+
+| Tool | Purpose |
+| --- | --- |
+| `search_local` | Hybrid dense + BM25 retrieval with citations |
+| `get_doc` | Fetch full document text or a single PDF/Pages page |
+| `reindex` | Index or refresh specific paths (defaults to configured roots) |
+| `watch` | Watch filesystem paths; debounce reindexing on change |
+| `stats` | Summaries: file count, chunk totals, vector cache size |
+| `import_chatgpt_export` | Convert a ChatGPT export and reindex the output |
+
+All tool inputs are validated with Zod and return JSON payloads.
+
+---
+
+## Operations & Deployment
+
+- Logs are single-line JSON (`{ level, msg, ... }`). Enable debug logs with `DEBUG=1`.
+- `npm run build` compiles TypeScript to `dist/` (NodeNext ESM).
+- Vercel builds run `npm install` → `npm run build`; no native binaries are required.
+- Clean artifacts with `npm run clean`.
+
+### Offline Model Prep
+```bash
+npm run models:download
+export TRANSFORMERS_OFFLINE=1
+```
+
+### CLI Helpers
+- `npm run index -- <paths...>` – batch reindex.
+- `npm run watch -- <paths...>` – stream JSON events while auto-indexing.
+- `npm run typecheck` – strict TS compile without emit.
+- `npm test` – Vitest suite (uses fake embeddings for speed).
+
+---
+
+## Tests
+
+```bash
+npm test
+```
+
+Includes:
+- Chunk boundary validation (`tests/chunk.test.ts`).
+- End-to-end reindex + search over fixtures (`tests/index-search.test.ts`).
+
+---
+
+## Styling & Conventions
+
+- TypeScript, `moduleResolution: NodeNext`, strict mode.
+- Functions use verbNoun names; modules stay under ~200 LOC where practical.
+- Comments explain *why*, not *what*.
+- Errors bubble with concise messages; logs remain structured.
+- MCP outputs are deterministic and JSON-serializable.
+
+---
+
+## Security & Privacy
+
+- Roots are whitelisted; realpaths prevent traversal or symlink escape.
+- ZipSlip guarded for `.pages` archives.
+- No outbound requests unless explicitly configured.
+- Treat ChatGPT exports and indexed documents as sensitive local data.
+
+---
+
+## License
+
+MIT (add your preferred license file).

--- a/mcp.json
+++ b/mcp.json
@@ -1,0 +1,13 @@
+{
+  "name": "mcp-nn",
+  "description": "Offline MCP server for NarcoNations.org research corpus",
+  "transport": "stdio",
+  "tools": [
+    "search_local",
+    "get_doc",
+    "reindex",
+    "watch",
+    "stats",
+    "import_chatgpt_export"
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.18.1",
         "@xenova/transformers": "^2.17.2",
         "adm-zip": "^0.5.16",
         "chokidar": "^4.0.3",
@@ -36,9 +37,6 @@
       },
       "engines": {
         "node": ">=20.0.0"
-      },
-      "optionalDependencies": {
-        "sqlite3": "^5.1.7"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -496,13 +494,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@gar/promisify": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
-      "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/@huggingface/jinja": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.2.2.tgz",
@@ -635,6 +626,47 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.18.1.tgz",
+      "integrity": "sha512-d//GE8/Yh7aC3e7p+kZG8JqqEAwwDUmAfvH1quogtbk+ksS6E0RR6toKKESPYYZVre0meqkJb27zb+dhqE9Sgw==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.6",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.0.1",
+        "express-rate-limit": "^7.5.0",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.23.8",
+        "zod-to-json-schema": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/zod-to-json-schema": {
+      "version": "3.24.6",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
+      "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.24.1"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -668,49 +700,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@npmcli/fs": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.1.tgz",
-      "integrity": "sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "@gar/promisify": "^1.0.1",
-        "semver": "^7.3.5"
-      }
-    },
-    "node_modules/@npmcli/move-file": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
-      "integrity": "sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==",
-      "deprecated": "This functionality has been moved to @npmcli/fs",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "mkdirp": "^1.0.4",
-        "rimraf": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@npmcli/move-file/node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -1085,16 +1074,6 @@
         "win32"
       ]
     },
-    "node_modules/@tootallnate/once": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
@@ -1324,12 +1303,18 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/abbrev": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "license": "ISC",
-      "optional": true
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/acorn": {
       "version": "8.15.0",
@@ -1366,69 +1351,27 @@
         "node": ">=12.0"
       }
     },
-    "node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
-        "debug": "4"
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
       },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/agent-base/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/agentkeepalive": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
-      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "humanize-ms": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      }
-    },
-    "node_modules/aggregate-error": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "clean-stack": "^2.0.0",
-        "indent-string": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1445,43 +1388,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/aproba": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
-      "integrity": "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==",
-      "license": "ISC",
-      "optional": true
-    },
-    "node_modules/are-we-there-yet": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
-      "integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
-      "deprecated": "This package is no longer supported.",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/are-we-there-yet/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/arg": {
@@ -1523,13 +1429,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/bare-events": {
       "version": "2.7.0",
@@ -1635,16 +1534,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
     "node_modules/bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -1682,15 +1571,41 @@
       "integrity": "sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw==",
       "license": "MIT"
     },
-    "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+    "node_modules/body-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
+      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.0",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.6.3",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.0",
+        "raw-body": "^3.0.0",
+        "type-is": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/body-parser/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/braces": {
@@ -1735,6 +1650,15 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "license": "MIT"
     },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -1745,61 +1669,33 @@
         "node": ">=8"
       }
     },
-    "node_modules/cacache": {
-      "version": "15.3.0",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz",
-      "integrity": "sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==",
-      "license": "ISC",
-      "optional": true,
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
       "dependencies": {
-        "@npmcli/fs": "^1.0.0",
-        "@npmcli/move-file": "^1.0.1",
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "glob": "^7.1.4",
-        "infer-owner": "^1.0.4",
-        "lru-cache": "^6.0.0",
-        "minipass": "^3.1.1",
-        "minipass-collect": "^1.0.2",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.2",
-        "mkdirp": "^1.0.3",
-        "p-map": "^4.0.0",
-        "promise-inflight": "^1.0.1",
-        "rimraf": "^3.0.2",
-        "ssri": "^8.0.1",
-        "tar": "^6.0.2",
-        "unique-filename": "^1.1.1"
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
       },
       "engines": {
-        "node": ">= 10"
+        "node": ">= 0.4"
       }
     },
-    "node_modules/cacache/node_modules/chownr": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-      "license": "ISC",
-      "optional": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/cacache/node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "license": "ISC",
-      "optional": true,
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
       "dependencies": {
-        "glob": "^7.1.3"
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
       },
-      "bin": {
-        "rimraf": "bin.js"
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/chai": {
@@ -1850,16 +1746,6 @@
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "license": "ISC"
     },
-    "node_modules/clean-stack": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/color": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
@@ -1901,35 +1787,83 @@
         "simple-swizzle": "^0.2.2"
       }
     },
-    "node_modules/color-support": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-      "license": "ISC",
-      "optional": true,
-      "bin": {
-        "color-support": "bin.js"
+    "node_modules/content-disposition": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
+      "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "license": "MIT",
-      "optional": true
+    "node_modules/content-disposition/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
-    "node_modules/console-control-strings": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
-      "license": "ISC",
-      "optional": true
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/create-require": {
       "version": "1.1.1",
@@ -1942,7 +1876,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -1996,12 +1929,14 @@
         "node": ">=4.0.0"
       }
     },
-    "node_modules/delegates": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "license": "MIT",
-      "optional": true
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.0",
@@ -2037,6 +1972,20 @@
         "underscore": "^1.13.1"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -2044,12 +1993,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/encoding": {
       "version": "0.1.13",
@@ -2057,6 +2021,7 @@
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
       }
@@ -2070,22 +2035,23 @@
         "once": "^1.4.0"
       }
     },
-    "node_modules/env-paths": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
-      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "license": "MIT",
-      "optional": true,
       "engines": {
-        "node": ">=6"
+        "node": ">= 0.4"
       }
     },
-    "node_modules/err-code": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
-      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "license": "MIT",
-      "optional": true
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
@@ -2093,6 +2059,18 @@
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.25.10",
@@ -2136,6 +2114,12 @@
         "@esbuild/win32-x64": "0.25.10"
       }
     },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -2159,6 +2143,36 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/expand-template": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
@@ -2178,6 +2192,80 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/express": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
+      "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.0",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
+      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/express/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/extend-shallow": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
@@ -2189,6 +2277,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
     },
     "node_modules/fast-fifo": {
       "version": "1.3.2",
@@ -2211,6 +2305,12 @@
       "engines": {
         "node": ">=8.6.0"
       }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "license": "MIT"
     },
     "node_modules/fast-xml-parser": {
       "version": "5.2.5",
@@ -2239,13 +2339,6 @@
         "reusify": "^1.0.4"
       }
     },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -2256,6 +2349,40 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
+      "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/finalhandler/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/flatbuffers": {
@@ -2322,31 +2449,29 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "license": "MIT"
-    },
-    "node_modules/fs-minipass": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "license": "ISC",
-      "optional": true
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -2363,25 +2488,50 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/gauge": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
-      "integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
-      "deprecated": "This package is no longer supported.",
-      "license": "ISC",
-      "optional": true,
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
       "dependencies": {
-        "aproba": "^1.0.3 || ^2.0.0",
-        "color-support": "^1.1.3",
-        "console-control-strings": "^1.1.0",
-        "has-unicode": "^2.0.1",
-        "signal-exit": "^3.0.7",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1",
-        "wide-align": "^1.1.5"
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-tsconfig": {
@@ -2403,28 +2553,6 @@
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
       "license": "MIT"
     },
-    "node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/glob-parent": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -2437,12 +2565,17 @@
         "node": ">= 6"
       }
     },
-    "node_modules/graceful-fs": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "license": "ISC",
-      "optional": true
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/gray-matter": {
       "version": "4.0.3",
@@ -2465,93 +2598,53 @@
       "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==",
       "license": "ISC"
     },
-    "node_modules/has-unicode": {
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-errors/node_modules/statuses": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
-      "license": "ISC",
-      "optional": true
-    },
-    "node_modules/http-cache-semantics": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
-      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
-      "license": "BSD-2-Clause",
-      "optional": true
-    },
-    "node_modules/http-proxy-agent": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
-      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@tootallnate/once": "1",
-        "agent-base": "6",
-        "debug": "4"
-      },
       "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/http-proxy-agent/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/https-proxy-agent/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/humanize-ms": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "ms": "^2.0.0"
+        "node": ">= 0.8"
       }
     },
     "node_modules/iconv-lite": {
@@ -2559,7 +2652,6 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -2599,45 +2691,6 @@
       "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
       "license": "MIT"
     },
-    "node_modules/imurmurhash": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=0.8.19"
-      }
-    },
-    "node_modules/indent-string": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/infer-owner": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
-      "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
-      "license": "ISC",
-      "optional": true
-    },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -2650,14 +2703,13 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
-    "node_modules/ip-address": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
-      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "license": "MIT",
-      "optional": true,
       "engines": {
-        "node": ">= 12"
+        "node": ">= 0.10"
       }
     },
     "node_modules/is-arrayish": {
@@ -2688,7 +2740,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2706,13 +2758,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-lambda": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
-      "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -2721,6 +2766,12 @@
       "engines": {
         "node": ">=0.12.0"
       }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
     },
     "node_modules/is-url": {
       "version": "1.2.4",
@@ -2738,7 +2789,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/jackspeak": {
@@ -2776,6 +2826,12 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "license": "MIT"
     },
     "node_modules/jszip": {
       "version": "3.10.1",
@@ -2831,19 +2887,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/magic-string": {
       "version": "0.30.19",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
@@ -2860,34 +2903,6 @@
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/make-fetch-happen": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
-      "integrity": "sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "agentkeepalive": "^4.1.3",
-        "cacache": "^15.2.0",
-        "http-cache-semantics": "^4.1.0",
-        "http-proxy-agent": "^4.0.1",
-        "https-proxy-agent": "^5.0.0",
-        "is-lambda": "^1.0.1",
-        "lru-cache": "^6.0.0",
-        "minipass": "^3.1.3",
-        "minipass-collect": "^1.0.2",
-        "minipass-fetch": "^1.3.2",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.4",
-        "negotiator": "^0.6.2",
-        "promise-retry": "^2.0.1",
-        "socks-proxy-agent": "^6.0.0",
-        "ssri": "^8.0.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
     },
     "node_modules/mammoth": {
       "version": "1.11.0",
@@ -2913,6 +2928,36 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -2935,6 +2980,27 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/mimic-response": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
@@ -2947,19 +3013,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -2967,116 +3020,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/minipass-collect": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
-      "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/minipass-fetch": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
-      "integrity": "sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "minipass": "^3.1.0",
-        "minipass-sized": "^1.0.3",
-        "minizlib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "optionalDependencies": {
-        "encoding": "^0.1.12"
-      }
-    },
-    "node_modules/minipass-flush": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
-      "integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/minipass-pipeline": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
-      "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/minipass-sized": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
-      "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/minizlib": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/mkdirp-classic": {
@@ -3117,11 +3060,10 @@
       "license": "MIT"
     },
     "node_modules/negotiator": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
-      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -3170,79 +3112,37 @@
         }
       }
     },
-    "node_modules/node-gyp": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.4.1.tgz",
-      "integrity": "sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==",
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "env-paths": "^2.2.0",
-        "glob": "^7.1.4",
-        "graceful-fs": "^4.2.6",
-        "make-fetch-happen": "^9.1.0",
-        "nopt": "^5.0.0",
-        "npmlog": "^6.0.0",
-        "rimraf": "^3.0.2",
-        "semver": "^7.3.5",
-        "tar": "^6.1.2",
-        "which": "^2.0.2"
-      },
-      "bin": {
-        "node-gyp": "bin/node-gyp.js"
-      },
       "engines": {
-        "node": ">= 10.12.0"
+        "node": ">=0.10.0"
       }
     },
-    "node_modules/node-gyp/node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/nopt": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
-      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
-      "license": "ISC",
-      "optional": true,
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
       "dependencies": {
-        "abbrev": "1"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
+        "ee-first": "1.1.1"
       },
       "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/npmlog": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
-      "integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
-      "deprecated": "This package is no longer supported.",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "are-we-there-yet": "^3.0.0",
-        "console-control-strings": "^1.1.0",
-        "gauge": "^4.0.3",
-        "set-blocking": "^2.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": ">= 0.8"
       }
     },
     "node_modules/once": {
@@ -3313,22 +3213,6 @@
       "integrity": "sha512-pkEqbDyl8ou5cpq+VsnQbe/WlEy5qS7xPzMS1U55OCG9KPvwFD46zDbxQIj3egJSFc3D+XhYOPUzz49zQAVy7A==",
       "license": "BSD-2-Clause"
     },
-    "node_modules/p-map": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "aggregate-error": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -3341,6 +3225,15 @@
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
       "license": "(MIT AND Zlib)"
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
@@ -3355,7 +3248,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3396,6 +3288,16 @@
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/pathe": {
@@ -3445,6 +3347,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.0.tgz",
+      "integrity": "sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/platform": {
@@ -3556,27 +3467,6 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "license": "MIT"
     },
-    "node_modules/promise-inflight": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
-      "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
-      "license": "ISC",
-      "optional": true
-    },
-    "node_modules/promise-retry": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
-      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "err-code": "^2.0.2",
-        "retry": "^0.12.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/protobufjs": {
       "version": "6.11.4",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.4.tgz",
@@ -3603,6 +3493,19 @@
         "pbts": "bin/pbts"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/pump": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
@@ -3611,6 +3514,30 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/queue-microtask": {
@@ -3632,6 +3559,46 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.1.tgz",
+      "integrity": "sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.7.0",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
+      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/rc": {
       "version": "1.2.8",
@@ -3690,16 +3657,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
-      }
-    },
-    "node_modules/retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 4"
       }
     },
     "node_modules/reusify": {
@@ -3824,6 +3781,39 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -3857,8 +3847,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/section-matter": {
       "version": "1.0.0",
@@ -3885,18 +3874,71 @@
         "node": ">=10"
       }
     },
-    "node_modules/set-blocking": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
-      "license": "ISC",
-      "optional": true
+    "node_modules/send": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
+      "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "mime-types": "^3.0.1",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/send/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
     },
     "node_modules/setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
       "license": "MIT"
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
     },
     "node_modules/sharp": {
       "version": "0.32.6",
@@ -3925,7 +3967,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -3938,10 +3979,81 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/siginfo": {
@@ -3950,13 +4062,6 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "license": "ISC",
-      "optional": true
     },
     "node_modules/simple-concat": {
       "version": "1.0.1",
@@ -4012,65 +4117,6 @@
         "is-arrayish": "^0.3.1"
       }
     },
-    "node_modules/smart-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 6.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/socks": {
-      "version": "2.8.7",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
-      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "ip-address": "^10.0.1",
-        "smart-buffer": "^4.2.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/socks-proxy-agent": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.2.1.tgz",
-      "integrity": "sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "agent-base": "^6.0.2",
-        "debug": "^4.3.3",
-        "socks": "^2.6.2"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/socks-proxy-agent/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -4106,57 +4152,21 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "license": "BSD-3-Clause"
     },
-    "node_modules/sqlite3": {
-      "version": "5.1.7",
-      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-5.1.7.tgz",
-      "integrity": "sha512-GGIyOiFaG+TUra3JIfkI/zGP8yZYLPQ0pl1bH+ODjiX57sPhrLU5sQJn1y9bDKZUFYkX1crlrPfSYt0BKKdkog==",
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "node-addon-api": "^7.0.0",
-        "prebuild-install": "^7.1.1",
-        "tar": "^6.1.11"
-      },
-      "optionalDependencies": {
-        "node-gyp": "8.x"
-      },
-      "peerDependencies": {
-        "node-gyp": "8.x"
-      },
-      "peerDependenciesMeta": {
-        "node-gyp": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/sqlite3/node_modules/node-addon-api": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
-      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/ssri": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
-      "integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "minipass": "^3.1.1"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/std-env": {
       "version": "3.9.0",
@@ -4191,7 +4201,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -4222,7 +4232,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -4288,24 +4298,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/tar": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^5.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/tar-fs": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
@@ -4329,26 +4321,6 @@
         "b4a": "^1.6.4",
         "fast-fifo": "^1.2.0",
         "streamx": "^2.15.0"
-      }
-    },
-    "node_modules/tar/node_modules/chownr": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-      "license": "ISC",
-      "optional": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/tar/node_modules/minipass": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-      "license": "ISC",
-      "optional": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/tesseract.js": {
@@ -4488,6 +4460,15 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -4570,6 +4551,20 @@
         "node": "*"
       }
     },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
@@ -4596,24 +4591,22 @@
       "integrity": "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==",
       "license": "MIT"
     },
-    "node_modules/unique-filename": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
-      "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "unique-slug": "^2.0.0"
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
-    "node_modules/unique-slug": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
-      "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
-      "license": "ISC",
-      "optional": true,
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "license": "BSD-2-Clause",
       "dependencies": {
-        "imurmurhash": "^0.1.4"
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -4641,6 +4634,15 @@
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/vite": {
       "version": "7.1.6",
@@ -4919,7 +4921,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -4946,16 +4947,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/wide-align": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
-      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "string-width": "^1.0.2 || 2 || 3 || 4"
       }
     },
     "node_modules/wrap-ansi": {
@@ -5079,13 +5070,6 @@
       "engines": {
         "node": ">=4.0"
       }
-    },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC",
-      "optional": true
     },
     "node_modules/yn": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
     "watch": "ts-node src/cli-watch.ts",
     "models:download": "node scripts/prefetch-model.mjs",
     "clean": "rimraf .mcp-nn dist",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "chatgpt:to-md": "ts-node scripts/chatgpt-export-to-md.ts",
+    "chatgpt:index": "ts-node scripts/chatgpt-export-to-md.ts ./fixtures/chatgpt-export-sample && ts-node src/cli-index.ts ./docs/chatgpt-export-md",
+    "chatgpt:quickstart": "npm run chatgpt:to-md -- ~/Downloads/chatgpt-export && npm run index -- ./docs/chatgpt-export-md"
   },
   "keywords": [],
   "author": "",
@@ -27,6 +30,7 @@
   },
   "dependencies": {
     "@xenova/transformers": "^2.17.2",
+    "@modelcontextprotocol/sdk": "^1.18.1",
     "adm-zip": "^0.5.16",
     "chokidar": "^4.0.3",
     "fast-glob": "^3.3.3",
@@ -39,9 +43,6 @@
     "tesseract.js": "^6.0.1",
     "uuid": "^13.0.0",
     "zod": "^4.1.9"
-  },
-  "optionalDependencies": {
-    "sqlite3": "^5.1.7"
   },
   "devDependencies": {
     "@types/adm-zip": "^0.5.7",

--- a/scripts/chatgpt-export-to-md.ts
+++ b/scripts/chatgpt-export-to-md.ts
@@ -1,0 +1,139 @@
+// scripts/chatgpt-export-to-md.ts
+// Usage: npm run chatgpt:to-md -- /path/to/ChatGPT-export [outDir]
+import { promises as fs } from "fs";
+import path from "path";
+import crypto from "crypto";
+
+type AnyMsg = any;
+type AnyConv = any;
+
+const outDirDefault = path.join(process.cwd(), "docs", "chatgpt-export-md");
+const toISO = (n?: number) => (n ? new Date(n > 2e10 ? n : n * 1000).toISOString() : new Date().toISOString());
+
+const slug = (s: string) =>
+  (s || "untitled")
+    .toLowerCase()
+    .replace(/[^\w\-]+/g, "-")
+    .replace(/\-+/g, "-")
+    .replace(/(^\-|\-$)/g, "")
+    .slice(0, 80) || "untitled";
+
+function asText(content: any): string {
+  if (!content) return "";
+  if (Array.isArray(content)) {
+    const parts = content.map((c: any) => c?.text?.value ?? c?.string_value ?? "").filter(Boolean);
+    if (parts.length) return parts.join("\n\n");
+  }
+  if (content?.parts && Array.isArray(content.parts)) return content.parts.join("\n\n");
+  if (typeof content === "string") return content;
+  return JSON.stringify(content, null, 2);
+}
+
+function extractMessages(conv: AnyConv): { role: string; text: string; ts?: number }[] {
+  if (Array.isArray(conv?.messages)) {
+    return conv.messages
+      .map((m: AnyMsg) => ({
+        role: m?.author?.role || m?.role || "unknown",
+        text: asText(m?.content || m?.text),
+        ts: m?.create_time || m?.timestamp || m?.create_time_ms,
+      }))
+      .filter((m) => m.text?.trim());
+  }
+  if (conv?.mapping && typeof conv.mapping === "object") {
+    const msgs = Object.values(conv.mapping)
+      .map((n: any) => n?.message)
+      .filter(Boolean)
+      .map((m: any) => ({
+        role: m?.author?.role || m?.role || "unknown",
+        text: asText(m?.content),
+        ts: m?.create_time || m?.timestamp || m?.create_time_ms,
+      }))
+      .filter((m) => m.text?.trim());
+    return msgs.sort((a, b) => (a.ts ?? 0) - (b.ts ?? 0));
+  }
+  if (conv?.conversation?.messages) return extractMessages(conv.conversation);
+  return [];
+}
+
+async function loadExportJson(exportRoot: string): Promise<any> {
+  const candidates = [
+    path.join(exportRoot, "conversations.json"),
+    path.join(exportRoot, "conversations", "conversations.json"),
+    path.join(exportRoot, "export.json"),
+  ];
+  for (const p of candidates) {
+    try {
+      const raw = await fs.readFile(p, "utf8");
+      console.log(JSON.stringify({ level: "info", msg: "using_export_json", meta: { path: p } }));
+      return JSON.parse(raw);
+    } catch {}
+  }
+  throw new Error(`Could not find conversations.json in ${exportRoot}`);
+}
+
+async function ensureDir(p: string) {
+  await fs.mkdir(p, { recursive: true });
+}
+
+async function main() {
+  const argIdx = process.argv.findIndex((a) => a === "--");
+  const exportRoot = process.argv[argIdx >= 0 ? argIdx + 1 : 2] as string | undefined;
+  const outDirArg = process.argv[argIdx >= 0 ? argIdx + 2 : 3] as string | undefined;
+  if (!exportRoot) {
+    console.error("Usage: npm run chatgpt:to-md -- /path/to/ChatGPT-export [outDir]");
+    process.exit(1);
+  }
+  const data = await loadExportJson(exportRoot);
+  const conversations: AnyConv[] = Array.isArray(data) ? data : data.conversations ?? [];
+  if (!Array.isArray(conversations) || conversations.length === 0) {
+    console.error("No conversations found in export.");
+    process.exit(1);
+  }
+
+  const outDir = outDirArg || outDirDefault;
+  await ensureDir(outDir);
+
+  let written = 0;
+  for (const conv of conversations) {
+    const id: string = conv.id || conv.conversation_id || crypto.randomBytes(6).toString("hex");
+    const title: string = (conv.title || conv.gist || "Untitled").trim();
+    const created: number = conv.create_time || conv.create_time_unix || conv.create_time_ms || Date.now();
+    const model: string = conv.model_slug || conv.model || "";
+    const msgs = extractMessages(conv);
+
+    const header = [
+      "---",
+      `id: ${JSON.stringify(id)}`,
+      `title: ${JSON.stringify(title)}`,
+      `created: ${JSON.stringify(toISO(created))}`,
+      `model: ${JSON.stringify(model)}`,
+      `source: \"chatgpt-export\"`,
+      "---",
+      "",
+      `# ${title}`,
+      "",
+    ].join("\n");
+
+    const body = msgs
+      .map((m) => {
+        const role = m.role === "system" ? "system" : m.role?.replace(/^assistant$/, "assistant").replace(/^user$/, "user");
+        const when = m.ts ? toISO(m.ts) : "";
+        const text = (m.text || "").normalize("NFKC").trim();
+        return `## ${role}${when ? ` • ${when}` : ""}\n\n${text}\n`;
+      })
+      .join("\n");
+
+    const fname = `${slug(title)}-${id.slice(0, 8)}.md`;
+    await fs.writeFile(path.join(outDir, fname), `${header}${body}`, "utf8");
+    written++;
+  }
+
+  console.log(
+    JSON.stringify({ level: "info", msg: "chatgpt_export_converted", meta: { conversations: conversations.length, filesWritten: written, outDir } }),
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,0 +1,24 @@
+import { loadConfig } from "./config.js";
+import { AppConfig } from "./types.js";
+import { Store } from "./store/store.js";
+import { Embedder, getEmbedder } from "./pipeline/embed.js";
+
+export interface AppContext {
+  config: AppConfig;
+  store: Store;
+  embedder: Embedder;
+}
+
+let contextPromise: Promise<AppContext> | null = null;
+
+export async function getAppContext(): Promise<AppContext> {
+  if (!contextPromise) {
+    contextPromise = (async () => {
+      const config = await loadConfig();
+      const store = await Store.load(config);
+      const embedder = getEmbedder(config);
+      return { config, store, embedder };
+    })();
+  }
+  return contextPromise;
+}

--- a/src/cli-index.ts
+++ b/src/cli-index.ts
@@ -1,1 +1,15 @@
-console.log(JSON.stringify({ level: 'info', msg: 'index CLI stub — Codex will implement reindex(paths...)' }));
+#!/usr/bin/env node
+import { getAppContext } from "./app.js";
+import { reindex } from "./tools/reindex.js";
+
+async function main() {
+  const args = process.argv.slice(2);
+  const context = await getAppContext();
+  const stats = await reindex(context, args.length ? { paths: args } : {});
+  process.stdout.write(`${JSON.stringify(stats)}\n`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/cli-watch.ts
+++ b/src/cli-watch.ts
@@ -1,1 +1,17 @@
-console.log(JSON.stringify({ level: 'info', msg: 'watch CLI stub — Codex will implement chokidar + events' }));
+#!/usr/bin/env node
+import { getAppContext } from "./app.js";
+import { watch } from "./tools/watch.js";
+
+async function main() {
+  const args = process.argv.slice(2);
+  const context = await getAppContext();
+  await watch(context, args.length ? { paths: args } : {}, (event) => {
+    process.stdout.write(`${JSON.stringify(event)}\n`);
+  });
+  process.stdin.resume();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,73 @@
+import { promises as fs } from "fs";
+import path from "path";
+import { AppConfig } from "./types.js";
+import { logger } from "./utils/logger.js";
+
+const DEFAULT_CONFIG: AppConfig = {
+  roots: {
+    roots: ["./docs", "./public/dossiers", "./docs/chatgpt-export-md"],
+    include: [".pdf", ".md", ".txt", ".docx", ".pages"],
+    exclude: ["**/node_modules/**", ".git/**"],
+  },
+  index: {
+    chunkSize: 3500,
+    chunkOverlap: 120,
+    ocrEnabled: true,
+    ocrTriggerMinChars: 100,
+    useSQLiteVSS: false,
+    model: "Xenova/all-MiniLM-L6-v2",
+    maxFileSizeMB: 200,
+    concurrency: 2,
+    languages: ["eng"],
+  },
+  out: {
+    dataDir: ".mcp-nn",
+  },
+};
+
+function deepMerge<T extends Record<string, any>>(target: T, source: Partial<T>): T {
+  const result: Record<string, any> = { ...target };
+  for (const [key, value] of Object.entries(source)) {
+    if (value === undefined) continue;
+    const current = (result as Record<string, any>)[key];
+    if (Array.isArray(value)) {
+      (result as Record<string, any>)[key] = [...value];
+    } else if (value && typeof value === "object" && current && typeof current === "object" && !Array.isArray(current)) {
+      (result as Record<string, any>)[key] = deepMerge(current, value as any);
+    } else {
+      (result as Record<string, any>)[key] = value;
+    }
+  }
+  return result as T;
+}
+
+export async function loadConfig(): Promise<AppConfig> {
+  const dataDirOverride = process.env.MCP_NN_DATA_DIR;
+  const baseConfig: AppConfig = JSON.parse(JSON.stringify(DEFAULT_CONFIG));
+  if (dataDirOverride) {
+    baseConfig.out.dataDir = dataDirOverride;
+  }
+
+  const dataDir = path.resolve(process.cwd(), baseConfig.out.dataDir);
+  await fs.mkdir(dataDir, { recursive: true });
+  const configPath = path.join(dataDir, "config.json");
+
+  let userConfig: Partial<AppConfig> = {};
+  try {
+    const raw = await fs.readFile(configPath, "utf8");
+    userConfig = JSON.parse(raw);
+  } catch (err: any) {
+    if (err.code !== "ENOENT") {
+      logger.warn("config-load-failed", { error: err.message });
+    }
+  }
+
+  const merged = deepMerge(baseConfig, userConfig);
+  merged.out.dataDir = dataDir;
+  if (process.env.TRANSFORMERS_CACHE) {
+    merged.out.modelCacheDir = process.env.TRANSFORMERS_CACHE;
+  }
+
+  await fs.writeFile(configPath, JSON.stringify({ ...merged, out: { ...merged.out, dataDir: path.relative(process.cwd(), merged.out.dataDir) } }, null, 2));
+  return merged;
+}

--- a/src/indexers/index.ts
+++ b/src/indexers/index.ts
@@ -1,0 +1,37 @@
+import path from "path";
+import { promises as fs } from "fs";
+import { AppConfig } from "../types.js";
+import { indexPdf } from "./pdf.js";
+import { indexMarkdown } from "./markdown.js";
+import { indexText } from "./text.js";
+import { indexWord } from "./word.js";
+import { indexPages } from "./pages.js";
+import { IndexContext, IndexResult } from "./types.js";
+
+const INDEXERS: Record<string, (ctx: IndexContext) => Promise<IndexResult>> = {
+  ".pdf": indexPdf,
+  ".md": indexMarkdown,
+  ".markdown": indexMarkdown,
+  ".txt": indexText,
+  ".docx": indexWord,
+  ".pages": indexPages,
+};
+
+export async function indexPath(absolutePath: string, relativePath: string, config: AppConfig): Promise<IndexResult> {
+  const ext = path.extname(absolutePath).toLowerCase();
+  const stat = await fs.stat(absolutePath);
+  const maxBytes = (config.index.maxFileSizeMB ?? 200) * 1024 * 1024;
+  if (stat.size > maxBytes) {
+    return { chunks: [], warnings: [`file-too-large:${relativePath}`], partial: true };
+  }
+  const indexer = INDEXERS[ext];
+  if (!indexer) {
+    return { chunks: [], warnings: [`unsupported-extension:${ext}`], partial: true };
+  }
+  return indexer({
+    absolutePath,
+    relativePath,
+    config,
+    mtime: stat.mtimeMs,
+  });
+}

--- a/src/indexers/markdown.ts
+++ b/src/indexers/markdown.ts
@@ -1,0 +1,36 @@
+import { promises as fs } from "fs";
+import matter from "gray-matter";
+import { chunkText, normalizeText } from "../pipeline/chunk.js";
+import { chunkId } from "../utils/hash.js";
+import { IndexContext, IndexResult } from "./types.js";
+
+export const indexMarkdown = async (context: IndexContext): Promise<IndexResult> => {
+  const { absolutePath, relativePath, config, mtime } = context;
+  const raw = await fs.readFile(absolutePath, "utf8");
+  const parsed = matter(raw);
+  const tagsValue = parsed.data?.tags;
+  const tags = Array.isArray(tagsValue)
+    ? tagsValue.map((tag) => String(tag))
+    : tagsValue
+    ? [String(tagsValue)]
+    : [];
+
+  const body = normalizeText(parsed.content || "");
+  const fragments = chunkText(body, {
+    chunkSize: config.index.chunkSize,
+    chunkOverlap: config.index.chunkOverlap,
+  });
+
+  const chunks = fragments.map((fragment) => ({
+    id: chunkId(relativePath, undefined, fragment.start),
+    path: relativePath,
+    type: "markdown" as const,
+    offsetStart: fragment.start,
+    offsetEnd: fragment.end,
+    text: fragment.text,
+    tags,
+    mtime,
+  }));
+
+  return { chunks, warnings: [] };
+};

--- a/src/indexers/pages.ts
+++ b/src/indexers/pages.ts
@@ -1,0 +1,84 @@
+import AdmZip from "adm-zip";
+import { XMLParser } from "fast-xml-parser";
+import { chunkText } from "../pipeline/chunk.js";
+import { chunkId } from "../utils/hash.js";
+import { IndexContext, IndexResult } from "./types.js";
+
+function isSafeEntry(name: string): boolean {
+  return !name.includes("..") && !name.startsWith("/");
+}
+
+function extractTextFromXML(xml: string): string {
+  const parser = new XMLParser({ ignoreAttributes: false, removeNSPrefix: true, textNodeName: "text" });
+  const parsed = parser.parse(xml);
+  const texts: string[] = [];
+
+  const walk = (node: any) => {
+    if (node == null) return;
+    if (typeof node === "string") {
+      texts.push(node);
+      return;
+    }
+    if (Array.isArray(node)) {
+      for (const child of node) walk(child);
+      return;
+    }
+    if (typeof node === "object") {
+      if (typeof node.text === "string") {
+        texts.push(node.text);
+      }
+      for (const value of Object.values(node)) {
+        if (value !== node.text) {
+          walk(value);
+        }
+      }
+    }
+  };
+
+  walk(parsed);
+  return texts.join("\n");
+}
+
+export const indexPages = async (context: IndexContext): Promise<IndexResult> => {
+  const { absolutePath, relativePath, config, mtime } = context;
+  const zip = new AdmZip(absolutePath);
+  const warnings: string[] = [];
+  let xmlText = "";
+  let partial = false;
+
+  for (const entry of zip.getEntries()) {
+    if (!isSafeEntry(entry.entryName)) {
+      warnings.push(`skipped-unsafe-entry:${entry.entryName}`);
+      continue;
+    }
+    if (entry.entryName.endsWith(".xml") || entry.entryName.endsWith(".apxl")) {
+      xmlText = entry.getData().toString("utf8");
+      break;
+    }
+  }
+
+  if (!xmlText) {
+    warnings.push("pages-xml-not-found");
+    partial = true;
+  }
+
+  const text = xmlText ? extractTextFromXML(xmlText) : "";
+  const fragments = chunkText(text, {
+    chunkSize: config.index.chunkSize,
+    chunkOverlap: config.index.chunkOverlap,
+  });
+
+  const chunks = fragments.map((fragment, idx) => ({
+    id: chunkId(`${relativePath}#${idx}`, idx + 1, fragment.start),
+    path: relativePath,
+    type: "pages" as const,
+    page: idx + 1,
+    offsetStart: fragment.start,
+    offsetEnd: fragment.end,
+    text: fragment.text,
+    mtime,
+    partial,
+  }));
+
+  return { chunks, warnings, partial };
+};

--- a/src/indexers/pdf.ts
+++ b/src/indexers/pdf.ts
@@ -1,0 +1,62 @@
+import { promises as fs } from "fs";
+import pdfParse from "pdf-parse/lib/pdf-parse.js";
+import { chunkText } from "../pipeline/chunk.js";
+import { shouldRunOCR } from "../pipeline/detect-ocr.js";
+import { chunkId } from "../utils/hash.js";
+import { IndexContext, IndexResult } from "./types.js";
+import { logger } from "../utils/logger.js";
+
+export async function extractPdfPages(absolutePath: string): Promise<string[]> {
+  const buffer = await fs.readFile(absolutePath);
+  const pageTexts: string[] = [];
+  await pdfParse(buffer, {
+    pagerender: async (pageData: any) => {
+      const textContent = await pageData.getTextContent({ normalizeWhitespace: true });
+      const pageText = textContent.items.map((item: any) => item.str).join(" \n");
+      pageTexts.push(pageText);
+      return pageText;
+    },
+  });
+  return pageTexts;
+}
+
+export const indexPdf = async (context: IndexContext): Promise<IndexResult> => {
+  const { absolutePath, relativePath, config, mtime } = context;
+  const warnings: string[] = [];
+  let pageTexts: string[] = [];
+  try {
+    pageTexts = await extractPdfPages(absolutePath);
+  } catch (err: any) {
+    warnings.push(`pdf-parse-failed: ${err.message}`);
+    logger.warn("pdf-parse-failed", { path: relativePath, error: err.message });
+  }
+
+  let partial = false;
+  const chunks = pageTexts.flatMap((pageText, pageIndex) => {
+    const trimmed = pageText.trim();
+    if (!trimmed.length) {
+      partial = true;
+      return [];
+    }
+    if (config.index.ocrEnabled && shouldRunOCR(trimmed, config.index.ocrTriggerMinChars)) {
+      warnings.push(`ocr-suggested-page-${pageIndex + 1}`);
+      partial = true;
+    }
+    const fragments = chunkText(trimmed, {
+      chunkSize: config.index.chunkSize,
+      chunkOverlap: config.index.chunkOverlap,
+    });
+    return fragments.map((fragment) => ({
+      id: chunkId(`${relativePath}#${pageIndex + 1}`, pageIndex + 1, fragment.start),
+      path: relativePath,
+      type: "pdf" as const,
+      page: pageIndex + 1,
+      offsetStart: fragment.start,
+      offsetEnd: fragment.end,
+      text: fragment.text,
+      mtime,
+    }));
+  });
+
+  return { chunks, warnings, partial };
+};

--- a/src/indexers/text.ts
+++ b/src/indexers/text.ts
@@ -1,0 +1,23 @@
+import { promises as fs } from "fs";
+import { chunkText } from "../pipeline/chunk.js";
+import { chunkId } from "../utils/hash.js";
+import { IndexContext, IndexResult } from "./types.js";
+
+export const indexText = async (context: IndexContext): Promise<IndexResult> => {
+  const { absolutePath, relativePath, config, mtime } = context;
+  const raw = await fs.readFile(absolutePath, "utf8");
+  const fragments = chunkText(raw, {
+    chunkSize: config.index.chunkSize,
+    chunkOverlap: config.index.chunkOverlap,
+  });
+  const chunks = fragments.map((fragment) => ({
+    id: chunkId(relativePath, undefined, fragment.start),
+    path: relativePath,
+    type: "text" as const,
+    offsetStart: fragment.start,
+    offsetEnd: fragment.end,
+    text: fragment.text,
+    mtime,
+  }));
+  return { chunks, warnings: [] };
+};

--- a/src/indexers/types.ts
+++ b/src/indexers/types.ts
@@ -1,0 +1,16 @@
+import { AppConfig, Chunk } from "../types.js";
+
+export interface IndexContext {
+  absolutePath: string;
+  relativePath: string;
+  config: AppConfig;
+  mtime: number;
+}
+
+export interface IndexResult {
+  chunks: Chunk[];
+  warnings: string[];
+  partial?: boolean;
+}
+
+export type Indexer = (context: IndexContext) => Promise<IndexResult>;

--- a/src/indexers/word.ts
+++ b/src/indexers/word.ts
@@ -1,0 +1,25 @@
+import mammoth from "mammoth";
+import { chunkText } from "../pipeline/chunk.js";
+import { chunkId } from "../utils/hash.js";
+import { IndexContext, IndexResult } from "./types.js";
+
+export const indexWord = async (context: IndexContext): Promise<IndexResult> => {
+  const { absolutePath, relativePath, config, mtime } = context;
+  const result = await mammoth.extractRawText({ path: absolutePath });
+  const fragments = chunkText(result.value || "", {
+    chunkSize: config.index.chunkSize,
+    chunkOverlap: config.index.chunkOverlap,
+  });
+
+  const chunks = fragments.map((fragment) => ({
+    id: chunkId(relativePath, undefined, fragment.start),
+    path: relativePath,
+    type: "word" as const,
+    offsetStart: fragment.start,
+    offsetEnd: fragment.end,
+    text: fragment.text,
+    mtime,
+  }));
+
+  return { chunks, warnings: result.messages?.map((msg) => msg.message) ?? [] };
+};

--- a/src/pipeline/chunk.ts
+++ b/src/pipeline/chunk.ts
@@ -1,0 +1,71 @@
+export interface ChunkOptions {
+  chunkSize: number;
+  chunkOverlap: number;
+}
+
+export interface ChunkFragment {
+  text: string;
+  start: number;
+  end: number;
+}
+
+export function normalizeText(text: string): string {
+  const normalized = text.normalize("NFKC");
+  const replaced = normalized.replace(/\r\n?/g, "\n");
+  const collapsedSpaces = replaced.replace(/[\t\f\v ]+/g, " ");
+  return collapsedSpaces.replace(/\n{3,}/g, "\n\n").trim();
+}
+
+function findBoundary(text: string, from: number, to: number): number {
+  const window = text.slice(from, to);
+  const newlineIndex = window.lastIndexOf("\n\n");
+  if (newlineIndex !== -1) {
+    return from + newlineIndex + 2;
+  }
+  const sentenceMatch = window.match(/[\.?!。！？](?:\s|$)/g);
+  if (sentenceMatch && sentenceMatch.length) {
+    const last = window.lastIndexOf(sentenceMatch[sentenceMatch.length - 1]);
+    if (last !== -1) {
+      return from + last + sentenceMatch[sentenceMatch.length - 1].length;
+    }
+  }
+  const lastSpace = window.lastIndexOf(" ");
+  if (lastSpace !== -1) {
+    return from + lastSpace + 1;
+  }
+  return to;
+}
+
+export function chunkText(text: string, options: ChunkOptions): ChunkFragment[] {
+  const normalized = normalizeText(text);
+  const fragments: ChunkFragment[] = [];
+  const { chunkSize, chunkOverlap } = options;
+  if (!normalized.length) {
+    return fragments;
+  }
+
+  let start = 0;
+  while (start < normalized.length) {
+    let end = Math.min(start + chunkSize, normalized.length);
+    if (end < normalized.length) {
+      const boundary = findBoundary(normalized, start, end);
+      if (boundary > start + 50) {
+        end = boundary;
+      }
+    }
+    const leadingWhitespace = normalized.slice(start, end).match(/^\s*/)?.[0]?.length ?? 0;
+    const trailingWhitespace = normalized.slice(start, end).match(/\s*$/)?.[0]?.length ?? 0;
+    const actualStart = start + leadingWhitespace;
+    const actualEnd = end - trailingWhitespace;
+    if (actualEnd <= actualStart) {
+      break;
+    }
+    fragments.push({ text: normalized.slice(actualStart, actualEnd), start: actualStart, end: actualEnd });
+    if (end >= normalized.length) {
+      break;
+    }
+    start = Math.max(actualEnd - chunkOverlap, actualEnd);
+  }
+
+  return fragments;
+}

--- a/src/pipeline/detect-ocr.ts
+++ b/src/pipeline/detect-ocr.ts
@@ -1,0 +1,4 @@
+export function shouldRunOCR(pageText: string, threshold: number): boolean {
+  const clean = pageText.replace(/\s+/g, "").trim();
+  return clean.length < threshold;
+}

--- a/src/pipeline/embed.ts
+++ b/src/pipeline/embed.ts
@@ -1,0 +1,148 @@
+import { promises as fs } from "fs";
+import path from "path";
+import { AppConfig, Chunk } from "../types.js";
+import { logger } from "../utils/logger.js";
+import { sha1 } from "../utils/hash.js";
+
+export interface EmbeddingResult {
+  id: string;
+  vector: Float32Array;
+}
+
+interface CacheEntry {
+  model: string;
+  vector: number[];
+}
+
+const FALLBACK_DIM = 384;
+
+function pseudoVector(key: string): Float32Array {
+  const buffer = new Float32Array(FALLBACK_DIM);
+  let seed = 0;
+  for (let i = 0; i < key.length; i += 1) {
+    seed = (seed * 31 + key.charCodeAt(i)) >>> 0;
+  }
+  for (let i = 0; i < buffer.length; i += 1) {
+    seed = (seed * 1664525 + 1013904223) >>> 0;
+    buffer[i] = (seed % 1000) / 1000;
+  }
+  return buffer;
+}
+
+export class Embedder {
+  private cache = new Map<string, CacheEntry>();
+  private cacheLoaded = false;
+  private extractorPromise: Promise<any> | null = null;
+
+  constructor(private config: AppConfig) {}
+
+  private get cachePath(): string {
+    return path.join(this.config.out.dataDir, "embeddings-cache.json");
+  }
+
+  private async loadCache(): Promise<void> {
+    if (this.cacheLoaded) return;
+    try {
+      const raw = await fs.readFile(this.cachePath, "utf8");
+      const data: Record<string, CacheEntry> = JSON.parse(raw);
+      for (const [key, entry] of Object.entries(data)) {
+        this.cache.set(key, entry);
+      }
+    } catch (err: any) {
+      if (err.code !== "ENOENT") {
+        logger.warn("embed-cache-load-failed", { error: err.message });
+      }
+    }
+    this.cacheLoaded = true;
+  }
+
+  private async persistCache(): Promise<void> {
+    if (!this.cacheLoaded) return;
+    const data: Record<string, CacheEntry> = {};
+    for (const [key, entry] of this.cache.entries()) {
+      data[key] = entry;
+    }
+    await fs.writeFile(this.cachePath, JSON.stringify(data));
+  }
+
+  private async ensureExtractor(): Promise<any> {
+    if (process.env.MCP_NN_EMBED_FAKE === "1") {
+      return null;
+    }
+    if (!this.extractorPromise) {
+      this.extractorPromise = (async () => {
+        logger.info("model", { status: "loading", model: this.config.index.model });
+        const transformers = await import("@xenova/transformers");
+        const pipe = await transformers.pipeline("feature-extraction", this.config.index.model, {
+          cache_dir: this.config.out.modelCacheDir,
+        });
+        logger.info("model", { status: "ready", model: this.config.index.model });
+        return pipe;
+      })();
+    }
+    return this.extractorPromise;
+  }
+
+  private vectorFromCache(hash: string): Float32Array | null {
+    const entry = this.cache.get(hash);
+    if (!entry || entry.model !== this.config.index.model) {
+      return null;
+    }
+    return Float32Array.from(entry.vector);
+  }
+
+  private async vectorFromModel(text: string): Promise<Float32Array> {
+    if (process.env.MCP_NN_EMBED_FAKE === "1") {
+      return pseudoVector(text);
+    }
+    try {
+      const extractor = await this.ensureExtractor();
+      if (!extractor) {
+        return pseudoVector(text);
+      }
+      const output = await extractor(text, { pooling: "mean", normalize: true });
+      const data = Array.isArray(output?.data) ? output.data : output.tensor?.data ?? output;
+      if (data instanceof Float32Array) {
+        return data;
+      }
+      if (Array.isArray(data)) {
+        return Float32Array.from(data);
+      }
+      return pseudoVector(text);
+    } catch (err: any) {
+      logger.warn("embed-model-fallback", { error: err.message });
+      return pseudoVector(text);
+    }
+  }
+
+  private async embed(text: string, cacheKey: string): Promise<Float32Array> {
+    await this.loadCache();
+    const hash = sha1(`${cacheKey}:${this.config.index.model}`);
+    const cached = this.vectorFromCache(hash);
+    if (cached) {
+      return cached;
+    }
+    const vector = await this.vectorFromModel(text);
+    this.cache.set(hash, { model: this.config.index.model, vector: Array.from(vector) });
+    await this.persistCache();
+    return vector;
+  }
+
+  async embedChunk(chunk: Chunk): Promise<EmbeddingResult> {
+    const vector = await this.embed(chunk.text, `${chunk.id}:${chunk.mtime}`);
+    return { id: chunk.id, vector };
+  }
+
+  async embedQuery(query: string): Promise<Float32Array> {
+    return this.embed(query, `query:${query}`);
+  }
+}
+
+let embedder: Embedder | null = null;
+
+export function getEmbedder(config: AppConfig): Embedder {
+  if (!embedder) {
+    embedder = new Embedder(config);
+  }
+  return embedder;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,16 +1,95 @@
-import 'source-map-support/register';
-
-function log(level: string, msg: string, meta: Record<string, unknown> = {}) {
-  process.stdout.write(JSON.stringify({ level, msg, ...meta }) + '\n');
-}
+import "source-map-support/register";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+import { getAppContext } from "./app.js";
+import { searchLocal } from "./tools/searchLocal.js";
+import { getDoc } from "./tools/getDoc.js";
+import { reindex } from "./tools/reindex.js";
+import { watch, closeWatchers } from "./tools/watch.js";
+import { stats as statsTool } from "./tools/stats.js";
+import { importChatGPT } from "./tools/importChatGPT.js";
+import { logger } from "./utils/logger.js";
 
 async function main() {
-  log('info', 'mcp-nn skeleton ready', { mode: 'dev', transport: 'stdio' });
-  // Codex will replace this with the real MCP stdio server and tool registrations.
-  process.stdin.resume();
+  const context = await getAppContext();
+  const server = new McpServer(
+    { name: "mcp-nn", version: "1.1.0" },
+    { capabilities: { tools: {}, logging: {} } },
+  );
+
+  const searchSchema = {
+    query: z.string().min(1),
+    k: z.number().int().min(1).max(32).default(8),
+    alpha: z.number().min(0).max(1).default(0.65),
+    filters: z
+      .object({
+        type: z.array(z.enum(["pdf", "markdown", "text", "word", "pages"] as const)).optional(),
+      })
+      .optional(),
+  } as const;
+
+  server.tool("search_local", "Hybrid local search across the indexed corpus", searchSchema, async (args, _extra) => {
+    const data = await searchLocal(context, args);
+    return { content: [{ type: "text", text: JSON.stringify(data) }] };
+  });
+
+  const getDocSchema = {
+    path: z.string().min(1),
+    page: z.number().int().min(1).optional(),
+  } as const;
+
+  server.tool("get_doc", "Fetch a document or page from the indexed corpus", getDocSchema, async (args, _extra) => {
+    const data = await getDoc(context, args);
+    return { content: [{ type: "text", text: JSON.stringify(data) }] };
+  });
+
+  const reindexSchema = { paths: z.array(z.string()).optional() } as const;
+  server.tool("reindex", "Reindex one or more paths", reindexSchema, async (args, _extra) => {
+    const data = await reindex(context, args ?? {});
+    return { content: [{ type: "text", text: JSON.stringify(data) }] };
+  });
+
+  const watchSchema = { paths: z.array(z.string()).optional() } as const;
+  server.tool("watch", "Start filesystem watch and automatic reindexing", watchSchema, async (args, extra) => {
+    const response = await watch(context, args ?? {}, (event) => {
+      server.sendLoggingMessage({ level: "info", data: JSON.stringify(event) }, extra.sessionId).catch((err) => {
+        logger.warn("watch-notify-failed", { error: err.message });
+      });
+    });
+    return { content: [{ type: "text", text: JSON.stringify(response) }] };
+  });
+
+  server.tool("stats", "Return index statistics", {}, async (_args, _extra) => {
+    const data = await statsTool(context);
+    return { content: [{ type: "text", text: JSON.stringify(data) }] };
+  });
+
+  const importSchema = {
+    exportPath: z.string().min(1),
+    outDir: z.string().min(1).default("./docs/chatgpt-export-md"),
+  } as const;
+  server.tool("import_chatgpt_export", "Convert ChatGPT export and index it", importSchema, async (args, _extra) => {
+    const data = await importChatGPT(context, args);
+    return { content: [{ type: "text", text: JSON.stringify(data) }] };
+  });
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  logger.info("server-started", { transport: "stdio" });
+
+  const shutdown = async () => {
+    logger.info("server-shutdown", {});
+    await closeWatchers();
+    await server.close();
+    process.exit(0);
+  };
+
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
 }
 
 main().catch((err) => {
-  log('error', 'startup-failed', { err: String(err) });
+  logger.error("server-error", { error: err.message });
   process.exit(1);
 });

--- a/src/store/keyword.ts
+++ b/src/store/keyword.ts
@@ -1,0 +1,53 @@
+import FlexSearch from "flexsearch";
+import { Chunk } from "../types.js";
+
+interface KeywordHit {
+  id: string;
+  score: number;
+}
+
+export class KeywordStore {
+  private index: any;
+
+  constructor() {
+    const Document: any = (FlexSearch as any).Document ?? (FlexSearch as any).document;
+    this.index = new Document({
+      document: {
+        id: "id",
+        index: ["text", "tags"],
+      },
+      tokenize: "forward",
+      cache: 1000,
+    });
+  }
+
+  upsert(chunks: Chunk[]): void {
+    for (const chunk of chunks) {
+      this.index.remove(chunk.id);
+      this.index.add({ id: chunk.id, text: chunk.text, tags: (chunk.tags ?? []).join(" ") });
+    }
+  }
+
+  remove(ids: string[]): void {
+    for (const id of ids) {
+      this.index.remove(id);
+    }
+  }
+
+  search(query: string, limit: number): KeywordHit[] {
+    const hits: KeywordHit[] = [];
+    const seen = new Map<string, number>();
+    const results = this.index.search(query, { enrich: true, limit });
+    for (const section of results) {
+      for (const entry of section.result ?? []) {
+        const prev = seen.get(entry.id) ?? 0;
+        const score = Math.max(prev, entry.score ?? 0);
+        seen.set(entry.id, score);
+      }
+    }
+    for (const [id, score] of seen.entries()) {
+      hits.push({ id, score });
+    }
+    return hits.sort((a, b) => (b.score ?? 0) - (a.score ?? 0)).slice(0, limit);
+  }
+}

--- a/src/store/schema.ts
+++ b/src/store/schema.ts
@@ -1,0 +1,21 @@
+import { Chunk } from "../types.js";
+
+export interface FileManifestEntry {
+  path: string;
+  type: string;
+  chunkIds: string[];
+  mtime: number;
+  hash: string;
+  partial?: boolean;
+}
+
+export interface ManifestData {
+  version: number;
+  files: Record<string, FileManifestEntry>;
+  chunks: Record<string, Chunk>;
+  stats: {
+    updatedAt: number | null;
+  };
+}
+
+export const CURRENT_MANIFEST_VERSION = 1;

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,0 +1,210 @@
+import { promises as fs } from "fs";
+import path from "path";
+import { AppConfig, Chunk } from "../types.js";
+import { logger } from "../utils/logger.js";
+import { CURRENT_MANIFEST_VERSION, ManifestData } from "./schema.js";
+import { FlatVectorStore, VectorRecord } from "./vector-flat.js";
+import { createSQLiteVectorStore, SQLiteVectorStore } from "./vector-sqlitevss.js";
+import { KeywordStore } from "./keyword.js";
+
+export interface UpsertPayload {
+  filePath: string;
+  hash: string;
+  chunks: Chunk[];
+  vectors: VectorRecord[];
+  partial?: boolean;
+}
+
+export interface HybridOptions {
+  k: number;
+  alpha: number;
+  keywordLimit: number;
+  denseLimit: number;
+  filterTypes?: Set<string>;
+}
+
+export interface HybridResult {
+  id: string;
+  score: number;
+}
+
+export class Store {
+  private manifest: ManifestData = {
+    version: CURRENT_MANIFEST_VERSION,
+    files: {},
+    chunks: {},
+    stats: { updatedAt: null },
+  };
+  private vectorStore!: FlatVectorStore;
+  private sqliteStore: SQLiteVectorStore | null = null;
+  private keywordStore = new KeywordStore();
+
+  private constructor(private readonly config: AppConfig) {}
+
+  static async load(config: AppConfig): Promise<Store> {
+    const store = new Store(config);
+    await store.init();
+    return store;
+  }
+
+  private get manifestPath(): string {
+    return path.join(this.config.out.dataDir, "manifest.json");
+  }
+
+  private async init(): Promise<void> {
+    await fs.mkdir(this.config.out.dataDir, { recursive: true });
+    try {
+      const raw = await fs.readFile(this.manifestPath, "utf8");
+      this.manifest = JSON.parse(raw) as ManifestData;
+    } catch (err: any) {
+      if (err.code !== "ENOENT") {
+        logger.warn("manifest-load-failed", { error: err.message });
+      }
+    }
+
+    this.vectorStore = await FlatVectorStore.create(this.config.out.dataDir);
+    if (this.config.index.useSQLiteVSS) {
+      this.sqliteStore = await createSQLiteVectorStore(this.config.out.dataDir);
+    }
+
+    // Rebuild keyword index from manifest
+    const chunks = Object.values(this.manifest.chunks ?? {});
+    if (chunks.length) {
+      this.keywordStore.upsert(chunks);
+    }
+  }
+
+  private async persistManifest(): Promise<void> {
+    await fs.writeFile(this.manifestPath, JSON.stringify(this.manifest, null, 2));
+  }
+
+  private async removeChunks(chunkIds: string[]): Promise<void> {
+    for (const id of chunkIds) {
+      delete this.manifest.chunks[id];
+    }
+    this.vectorStore.remove(chunkIds);
+    this.keywordStore.remove(chunkIds);
+    if (this.sqliteStore) {
+      await this.sqliteStore.remove(chunkIds);
+    }
+  }
+
+  async upsert(payload: UpsertPayload): Promise<void> {
+    const { filePath, hash, chunks, vectors, partial } = payload;
+    const previous = this.manifest.files[filePath];
+    if (previous) {
+      await this.removeChunks(previous.chunkIds);
+    }
+
+    this.manifest.files[filePath] = {
+      path: filePath,
+      type: chunks[0]?.type ?? "unknown",
+      chunkIds: chunks.map((chunk) => chunk.id),
+      mtime: chunks[0]?.mtime ?? Date.now(),
+      hash,
+      partial,
+    };
+    for (const chunk of chunks) {
+      this.manifest.chunks[chunk.id] = chunk;
+    }
+    this.keywordStore.upsert(chunks);
+    await this.vectorStore.upsert(vectors);
+    if (this.sqliteStore) {
+      await this.sqliteStore.upsert(vectors);
+    }
+    this.manifest.stats.updatedAt = Date.now();
+    await this.persistManifest();
+  }
+
+  async remove(filePath: string): Promise<void> {
+    const record = this.manifest.files[filePath];
+    if (!record) return;
+    await this.removeChunks(record.chunkIds);
+    delete this.manifest.files[filePath];
+    this.manifest.stats.updatedAt = Date.now();
+    await this.persistManifest();
+  }
+
+  getChunk(id: string): Chunk | undefined {
+    return this.manifest.chunks[id];
+  }
+
+  getChunks(ids: string[]): Chunk[] {
+    return ids.map((id) => this.manifest.chunks[id]).filter(Boolean) as Chunk[];
+  }
+
+  getFileRecord(pathKey: string) {
+    return this.manifest.files[pathKey];
+  }
+
+  listFiles(): string[] {
+    return Object.keys(this.manifest.files);
+  }
+
+  getChunkCount(): number {
+    return Object.keys(this.manifest.chunks).length;
+  }
+
+  getChunksByType(): Record<string, number> {
+    const tally: Record<string, number> = {};
+    for (const record of Object.values(this.manifest.files)) {
+      const count = tally[record.type] ?? 0;
+      tally[record.type] = count + record.chunkIds.length;
+    }
+    return tally;
+  }
+
+  getLastUpdated(): number | null {
+    return this.manifest.stats.updatedAt ?? null;
+  }
+
+  getVectorCount(): number {
+    return this.vectorStore.size();
+  }
+
+  searchKeyword(query: string, limit: number): Array<{ id: string; score: number }> {
+    return this.keywordStore.search(query, limit);
+  }
+
+  searchDense(vector: Float32Array, limit: number): Array<{ id: string; score: number }> {
+    return this.sqliteStore ? [] : this.vectorStore.search(vector, limit);
+  }
+
+  async searchDenseWithSQLite(vector: Float32Array, limit: number): Promise<Array<{ id: string; score: number }>> {
+    if (this.sqliteStore) {
+      return this.sqliteStore.search(vector, limit);
+    }
+    return this.vectorStore.search(vector, limit);
+  }
+
+  async hybrid(vector: Float32Array, query: string, options: HybridOptions): Promise<HybridResult[]> {
+    const { k, alpha, keywordLimit, denseLimit, filterTypes } = options;
+    const dense = await this.searchDenseWithSQLite(vector, denseLimit);
+    const keyword = this.searchKeyword(query, keywordLimit);
+
+    const denseMax = dense[0]?.score ?? 1;
+    const keywordMax = keyword[0]?.score ?? 1;
+    const scores = new Map<string, number>();
+
+    for (const hit of dense) {
+      const chunk = this.getChunk(hit.id);
+      if (filterTypes && chunk && !filterTypes.has(chunk.type)) continue;
+      const base = scores.get(hit.id) ?? 0;
+      const normalized = denseMax ? hit.score / denseMax : hit.score;
+      scores.set(hit.id, Math.max(base, alpha * normalized));
+    }
+
+    for (const hit of keyword) {
+      const chunk = this.getChunk(hit.id);
+      if (filterTypes && chunk && !filterTypes.has(chunk.type)) continue;
+      const base = scores.get(hit.id) ?? 0;
+      const normalized = keywordMax ? hit.score / keywordMax : hit.score;
+      scores.set(hit.id, base + (1 - alpha) * normalized);
+    }
+
+    return Array.from(scores.entries())
+      .map(([id, score]) => ({ id, score }))
+      .sort((a, b) => b.score - a.score)
+      .slice(0, k);
+  }
+}

--- a/src/store/vector-flat.ts
+++ b/src/store/vector-flat.ts
@@ -1,0 +1,142 @@
+import { promises as fs } from "fs";
+import path from "path";
+import { logger } from "../utils/logger.js";
+
+export interface VectorRecord {
+  id: string;
+  vector: Float32Array;
+}
+
+interface ManifestEntry {
+  offset: number;
+  length: number;
+  norm: number;
+}
+
+interface VectorManifest {
+  version: number;
+  dimension: number;
+  entries: Record<string, ManifestEntry>;
+}
+
+export class FlatVectorStore {
+  private vectors = new Map<string, Float32Array>();
+  private manifest: VectorManifest = { version: 1, dimension: 0, entries: {} };
+
+  private constructor(private readonly filePath: string, private readonly manifestPath: string) {}
+
+  static async create(dataDir: string): Promise<FlatVectorStore> {
+    const filePath = path.join(dataDir, "vectors.bin");
+    const manifestPath = path.join(dataDir, "vectors.json");
+    const store = new FlatVectorStore(filePath, manifestPath);
+    await store.load();
+    return store;
+  }
+
+  private async load(): Promise<void> {
+    try {
+      const raw = await fs.readFile(this.manifestPath, "utf8");
+      this.manifest = JSON.parse(raw) as VectorManifest;
+    } catch (err: any) {
+      if (err.code !== "ENOENT") {
+        logger.warn("vector-manifest-load-failed", { error: err.message });
+      }
+      this.manifest = { version: 1, dimension: 0, entries: {} };
+      return;
+    }
+
+    try {
+      const buffer = await fs.readFile(this.filePath);
+      const view = new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength);
+      for (const [id, entry] of Object.entries(this.manifest.entries)) {
+        const arr = new Float32Array(entry.length);
+        for (let i = 0; i < entry.length; i += 1) {
+          arr[i] = view.getFloat32((entry.offset + i) * 4, true);
+        }
+        this.vectors.set(id, arr);
+      }
+    } catch (err: any) {
+      if (err.code !== "ENOENT") {
+        logger.warn("vector-load-failed", { error: err.message });
+      }
+    }
+  }
+
+  private computeNorm(vector: Float32Array): number {
+    let sum = 0;
+    for (let i = 0; i < vector.length; i += 1) {
+      sum += vector[i] * vector[i];
+    }
+    return Math.sqrt(sum);
+  }
+
+  private async persist(): Promise<void> {
+    const entries = Array.from(this.vectors.entries()).sort((a, b) => a[0].localeCompare(b[0]));
+    const totalLength = entries.reduce((acc, [, vec]) => acc + vec.length, 0);
+    const buffer = Buffer.alloc(totalLength * 4);
+    const manifestEntries: Record<string, ManifestEntry> = {};
+    let offset = 0;
+    let dimension = 0;
+    for (const [id, vector] of entries) {
+      for (let i = 0; i < vector.length; i += 1) {
+        buffer.writeFloatLE(vector[i], (offset + i) * 4);
+      }
+      manifestEntries[id] = {
+        offset,
+        length: vector.length,
+        norm: this.computeNorm(vector),
+      };
+      offset += vector.length;
+      dimension = vector.length;
+    }
+    await fs.writeFile(this.filePath, buffer);
+    this.manifest = {
+      version: 1,
+      dimension: dimension || this.manifest.dimension,
+      entries: manifestEntries,
+    };
+    await fs.writeFile(this.manifestPath, JSON.stringify(this.manifest, null, 2));
+  }
+
+  async upsert(records: VectorRecord[]): Promise<void> {
+    let dirty = false;
+    for (const record of records) {
+      this.vectors.set(record.id, record.vector);
+      dirty = true;
+    }
+    if (dirty) {
+      await this.persist();
+    }
+  }
+
+  remove(ids: string[]): void {
+    for (const id of ids) {
+      this.vectors.delete(id);
+      delete this.manifest.entries[id];
+    }
+  }
+
+  search(vector: Float32Array, k: number): Array<{ id: string; score: number }> {
+    const results: Array<{ id: string; score: number }> = [];
+    const queryNorm = this.computeNorm(vector) || 1;
+    for (const [id, storedVector] of this.vectors.entries()) {
+      const manifestEntry = this.manifest.entries[id];
+      const storedNorm = (manifestEntry?.norm ?? this.computeNorm(storedVector)) || 1;
+      let dot = 0;
+      const dim = Math.min(vector.length, storedVector.length);
+      for (let i = 0; i < dim; i += 1) {
+        dot += vector[i] * storedVector[i];
+      }
+      const denom = queryNorm * storedNorm || 1;
+      const score = denom === 0 ? 0 : dot / denom;
+      results.push({ id, score });
+    }
+    return results
+      .sort((a, b) => b.score - a.score)
+      .slice(0, k);
+  }
+
+  size(): number {
+    return this.vectors.size;
+  }
+}

--- a/src/store/vector-sqlitevss.ts
+++ b/src/store/vector-sqlitevss.ts
@@ -1,0 +1,115 @@
+import path from "path";
+import { logger } from "../utils/logger.js";
+
+export interface SQLiteVectorStore {
+  upsert(records: { id: string; vector: Float32Array }[]): Promise<void>;
+  remove(ids: string[]): Promise<void>;
+  search(vector: Float32Array, k: number): Promise<Array<{ id: string; score: number }>>;
+  close(): Promise<void>;
+}
+
+export async function createSQLiteVectorStore(dataDir: string): Promise<SQLiteVectorStore | null> {
+  try {
+    const sqlite3 = await import("sqlite3").catch(() => null);
+    if (!sqlite3) {
+      throw new Error("sqlite3 not installed");
+    }
+    const { Database } = sqlite3 as any;
+    const dbPath = path.join(dataDir, "vectors.sqlite");
+    const db = new Database(dbPath);
+    await new Promise<void>((resolve, reject) => {
+      db.serialize(() => {
+        db.run("PRAGMA journal_mode=WAL", (err: any) => {
+          if (err) reject(err);
+        });
+        db.run(
+          "CREATE TABLE IF NOT EXISTS vectors (id TEXT PRIMARY KEY, vector BLOB NOT NULL)",
+          (err: any) => {
+            if (err) reject(err);
+          },
+        );
+        resolve();
+      });
+    });
+
+    const store: SQLiteVectorStore = {
+      async upsert(records) {
+        await new Promise<void>((resolve, reject) => {
+          const stmt = db.prepare("INSERT OR REPLACE INTO vectors (id, vector) VALUES (?, ?)");
+          for (const record of records) {
+            const buffer = Buffer.alloc(record.vector.length * 4);
+            for (let i = 0; i < record.vector.length; i += 1) {
+              buffer.writeFloatLE(record.vector[i], i * 4);
+            }
+            stmt.run(record.id, buffer);
+          }
+          stmt.finalize((err: any) => {
+            if (err) reject(err);
+            else resolve();
+          });
+        });
+      },
+      async remove(ids) {
+        await new Promise<void>((resolve, reject) => {
+          const stmt = db.prepare("DELETE FROM vectors WHERE id = ?");
+          for (const id of ids) {
+            stmt.run(id);
+          }
+          stmt.finalize((err: any) => {
+            if (err) reject(err);
+            else resolve();
+          });
+        });
+      },
+      async search(vector, k) {
+        // Without sqlite-vss extension, provide naive scan similar to flat store.
+        const vectors: Array<{ id: string; vector: Float32Array }> = await new Promise((resolve, reject) => {
+          db.all("SELECT id, vector FROM vectors", (err: any, rows: any[]) => {
+            if (err) {
+              reject(err);
+            } else {
+              resolve(
+                rows.map((row: any) => {
+                  const buf: Buffer = row.vector;
+                  const arr = new Float32Array(buf.length / 4);
+                  for (let i = 0; i < arr.length; i += 1) {
+                    arr[i] = buf.readFloatLE(i * 4);
+                  }
+                  return { id: row.id, vector: arr };
+                }),
+              );
+            }
+          });
+        });
+        const queryNorm = Math.sqrt(vector.reduce((acc, v) => acc + v * v, 0));
+        const results: Array<{ id: string; score: number }> = [];
+        for (const item of vectors) {
+          const norm = Math.sqrt(item.vector.reduce((acc, v) => acc + v * v, 0));
+          let dot = 0;
+          const dim = Math.min(vector.length, item.vector.length);
+          for (let i = 0; i < dim; i += 1) {
+            dot += vector[i] * item.vector[i];
+          }
+          const denom = (queryNorm || 1) * (norm || 1);
+          const score = denom === 0 ? 0 : dot / denom;
+          results.push({ id: item.id, score });
+        }
+        return results.sort((a, b) => b.score - a.score).slice(0, k);
+      },
+      async close() {
+        await new Promise<void>((resolve, reject) => {
+          db.close((err: any) => {
+            if (err) reject(err);
+            else resolve();
+          });
+        });
+      },
+    };
+
+    logger.info("sqlite-vector-store", { status: "enabled" });
+    return store;
+  } catch (err: any) {
+    logger.info("sqlite-vector-store", { status: "unavailable", reason: err?.message ?? String(err) });
+    return null;
+  }
+}

--- a/src/tools/getDoc.ts
+++ b/src/tools/getDoc.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+import { AppContext } from "../app.js";
+
+const InputSchema = z.object({
+  path: z.string().min(1),
+  page: z.number().int().min(1).optional(),
+});
+
+export async function getDoc(context: AppContext, input: unknown) {
+  const { store } = context;
+  const { path: filePath, page } = InputSchema.parse(input ?? {});
+  const record = store.getFileRecord(filePath);
+  if (!record) {
+    throw new Error(`File not indexed: ${filePath}`);
+  }
+  const chunks = store.getChunks(record.chunkIds);
+  const filtered = page ? chunks.filter((chunk) => chunk.page === page) : chunks;
+  const text = filtered.map((chunk) => chunk.text).join("\n\n");
+  return {
+    path: filePath,
+    page,
+    text,
+  };
+}

--- a/src/tools/importChatGPT.ts
+++ b/src/tools/importChatGPT.ts
@@ -1,0 +1,79 @@
+import { spawn } from "child_process";
+import path from "path";
+import { promises as fs } from "fs";
+import { z } from "zod";
+import { AppContext } from "../app.js";
+import { reindex } from "./reindex.js";
+
+const InputSchema = z.object({
+  exportPath: z.string().min(1),
+  outDir: z.string().min(1).default("./docs/chatgpt-export-md"),
+});
+
+type JsonEvent = { level: string; msg: string; meta?: Record<string, unknown> };
+
+function parseLastJSON(buffer: string): JsonEvent | null {
+  const lines = buffer.trim().split(/\r?\n/).reverse();
+  for (const line of lines) {
+    try {
+      return JSON.parse(line);
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}
+
+async function ensureOutDir(outDir: string) {
+  await fs.mkdir(outDir, { recursive: true });
+}
+
+function ensureWithinRepo(outDir: string) {
+  const repoRoot = process.cwd();
+  const relative = path.relative(repoRoot, outDir);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error(`Output directory must be inside the repository: ${outDir}`);
+  }
+  const top = relative.split(path.sep)[0];
+  if (top && !["docs", "public", "fixtures", ".mcp-nn"].includes(top)) {
+    throw new Error(`Output directory must be under docs/public/fixtures/.mcp-nn: ${outDir}`);
+  }
+}
+
+async function runConverter(exportPath: string, outDir: string): Promise<JsonEvent | null> {
+  const tsNode = path.join(process.cwd(), "node_modules", "ts-node", "dist", "bin.js");
+  const script = path.join(process.cwd(), "scripts", "chatgpt-export-to-md.ts");
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [tsNode, script, "--", exportPath, outDir], { stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += String(chunk);
+    });
+    child.stderr.on("data", (chunk) => {
+      process.stderr.write(chunk);
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code !== 0) {
+        return reject(new Error(`chatgpt-export-to-md exited with code ${code}`));
+      }
+      resolve(parseLastJSON(stdout));
+    });
+  });
+}
+
+export async function importChatGPT(context: AppContext, input: unknown) {
+  const { exportPath, outDir } = InputSchema.parse(input ?? {});
+  const outDirAbs = path.resolve(process.cwd(), outDir);
+  ensureWithinRepo(outDirAbs);
+  await ensureOutDir(outDirAbs);
+
+  const convertEvent = await runConverter(exportPath, outDirAbs);
+  const stats = await reindex(context, { paths: [outDirAbs] });
+  return {
+    filesWritten: convertEvent?.meta?.filesWritten ?? 0,
+    conversations: convertEvent?.meta?.conversations ?? 0,
+    outDir: path.relative(process.cwd(), outDirAbs),
+    indexed: stats,
+  };
+}

--- a/src/tools/reindex.ts
+++ b/src/tools/reindex.ts
@@ -1,0 +1,120 @@
+import { promises as fs } from "fs";
+import path from "path";
+import fg from "fast-glob";
+import { z } from "zod";
+import { AppContext } from "../app.js";
+import { indexPath } from "../indexers/index.js";
+import { sha1 } from "../utils/hash.js";
+import { toPosix } from "../utils/fs-guard.js";
+import { logger } from "../utils/logger.js";
+
+const InputSchema = z.object({
+  paths: z.array(z.string()).optional(),
+});
+
+interface ReindexStats {
+  indexed: number;
+  updated: number;
+  skipped: number;
+  removed: number;
+  warnings: string[];
+}
+
+async function hashFile(absolutePath: string): Promise<string> {
+  const data = await fs.readFile(absolutePath);
+  return sha1(data);
+}
+
+async function collectFiles(paths: string[], include: string[], exclude: string[]): Promise<string[]> {
+  const files: string[] = [];
+  for (const root of paths) {
+    const rootResolved = path.resolve(process.cwd(), root);
+    const stat = await fs.stat(rootResolved).catch(() => null);
+    if (stat?.isFile()) {
+      files.push(rootResolved);
+      continue;
+    }
+    if (!stat) {
+      continue;
+    }
+    const patterns = include.map((ext) => `**/*${ext}`);
+    try {
+      const entries = await fg(patterns, {
+        cwd: rootResolved,
+        ignore: exclude,
+        onlyFiles: true,
+        followSymbolicLinks: false,
+      });
+      for (const entry of entries) {
+        const absolute = path.join(rootResolved, entry);
+        files.push(absolute);
+      }
+    } catch (err: any) {
+      logger.warn("glob-failed", { path: rootResolved, error: err.message });
+    }
+  }
+  return files;
+}
+
+export async function reindex(context: AppContext, input: unknown): Promise<ReindexStats> {
+  const { config, store, embedder } = context;
+  const { paths } = InputSchema.parse(input ?? {});
+  const roots = paths && paths.length ? paths : config.roots.roots;
+  const files = await collectFiles(roots, config.roots.include, config.roots.exclude);
+  const repoRoot = process.cwd();
+  const stats: ReindexStats = { indexed: 0, updated: 0, skipped: 0, removed: 0, warnings: [] };
+  const seen = new Set<string>();
+
+  for (const absolutePath of files) {
+    const relativePath = toPosix(path.relative(repoRoot, absolutePath));
+    seen.add(relativePath);
+    const hash = await hashFile(absolutePath);
+    const existing = store.getFileRecord(relativePath);
+    if (existing && existing.hash === hash) {
+      stats.skipped += 1;
+      continue;
+    }
+    const result = await indexPath(absolutePath, relativePath, config);
+    if (!result.chunks.length) {
+      stats.warnings.push(...result.warnings);
+      if (existing) {
+        await store.remove(relativePath);
+        stats.removed += 1;
+      }
+      continue;
+    }
+    const vectors = [];
+    for (const chunk of result.chunks) {
+      const embedding = await embedder.embedChunk(chunk);
+      vectors.push(embedding);
+    }
+    await store.upsert({
+      filePath: relativePath,
+      hash,
+      chunks: result.chunks,
+      vectors,
+      partial: result.partial,
+    });
+    if (existing) {
+      stats.updated += 1;
+    } else {
+      stats.indexed += 1;
+    }
+    stats.warnings.push(...result.warnings);
+  }
+
+  const tracked = store.listFiles();
+  for (const pathKey of tracked) {
+    if (!seen.has(pathKey)) {
+      const absolute = path.resolve(repoRoot, pathKey);
+      const exists = await fs.access(absolute).then(() => true).catch(() => false);
+      if (!exists) {
+        await store.remove(pathKey);
+        stats.removed += 1;
+      }
+    }
+  }
+
+  logger.info("reindex-complete", { ...stats });
+  return stats;
+}

--- a/src/tools/searchLocal.ts
+++ b/src/tools/searchLocal.ts
@@ -1,0 +1,71 @@
+import { z } from "zod";
+import { AppContext } from "../app.js";
+import { buildSnippet } from "../utils/cite.js";
+import { ChunkType } from "../types.js";
+
+const chunkTypes = ["pdf", "markdown", "text", "word", "pages"] as const;
+
+const InputSchema = z.object({
+  query: z.string().min(1),
+  k: z.number().int().min(1).max(32).default(8),
+  alpha: z.number().min(0).max(1).default(0.65),
+  filters: z
+    .object({
+      type: z.array(z.enum(chunkTypes)).optional(),
+    })
+    .optional(),
+});
+
+interface SearchResult {
+  chunkId: string;
+  score: number;
+  text: string;
+  citation: {
+    filePath: string;
+    page?: number;
+    startChar?: number;
+    endChar?: number;
+    snippet: string;
+  };
+}
+
+export async function searchLocal(context: AppContext, input: unknown) {
+  const { store, embedder } = context;
+  const { query, k, alpha, filters } = InputSchema.parse(input ?? {});
+  const vector = await embedder.embedQuery(query);
+  const filterTypes: Set<ChunkType> | undefined = filters?.type ? new Set(filters.type) : undefined;
+  const hits = await store.hybrid(vector, query, {
+    k,
+    alpha,
+    keywordLimit: Math.max(16, k * 4),
+    denseLimit: Math.max(16, k * 4),
+    filterTypes,
+  });
+
+  const results = hits
+    .map((hit): SearchResult | null => {
+      const chunk = store.getChunk(hit.id);
+      if (!chunk) {
+        return null;
+      }
+      const citation = {
+        filePath: chunk.path,
+        page: chunk.page,
+        startChar: chunk.offsetStart,
+        endChar: chunk.offsetEnd,
+        snippet: buildSnippet(chunk.text, chunk.offsetStart, chunk.offsetEnd),
+      };
+      return {
+        chunkId: chunk.id,
+        score: hit.score,
+        text: chunk.text.slice(0, 600),
+        citation,
+      };
+    })
+    .filter((entry): entry is SearchResult => entry !== null);
+
+  return {
+    query,
+    results,
+  };
+}

--- a/src/tools/stats.ts
+++ b/src/tools/stats.ts
@@ -1,0 +1,13 @@
+import { AppContext } from "../app.js";
+
+export async function stats(context: AppContext) {
+  const { store } = context;
+  const files = store.listFiles();
+  return {
+    files: files.length,
+    chunks: store.getChunkCount(),
+    byType: store.getChunksByType(),
+    embeddingsCached: store.getVectorCount(),
+    lastIndexedAt: store.getLastUpdated(),
+  };
+}

--- a/src/tools/watch.ts
+++ b/src/tools/watch.ts
@@ -1,0 +1,71 @@
+import chokidar, { FSWatcher } from "chokidar";
+import path from "path";
+import { z } from "zod";
+import { AppContext } from "../app.js";
+import { reindex } from "./reindex.js";
+import { logger } from "../utils/logger.js";
+
+const InputSchema = z.object({
+  paths: z.array(z.string()).optional(),
+});
+
+type EmitFn = (event: { event: string; path: string; action: string }) => void;
+
+const activeWatchers: Set<FSWatcher> = new Set();
+
+export async function watch(context: AppContext, input: unknown, emit?: EmitFn) {
+  const { config } = context;
+  const { paths } = InputSchema.parse(input ?? {});
+  const watchRoots = paths && paths.length ? paths : config.roots.roots;
+  const ignores = config.roots.exclude;
+
+  const pending = new Map<string, NodeJS.Timeout>();
+  const schedule = (filePath: string) => {
+    const existing = pending.get(filePath);
+    if (existing) clearTimeout(existing);
+    const timer = setTimeout(async () => {
+      pending.delete(filePath);
+      try {
+        await reindex(context, { paths: [filePath] });
+      } catch (err: any) {
+        logger.warn("watch-reindex-failed", { error: err.message, path: filePath });
+      }
+    }, 250);
+    pending.set(filePath, timer);
+  };
+
+  const watcher = chokidar.watch(watchRoots, {
+    ignored: ignores,
+    ignoreInitial: true,
+    awaitWriteFinish: { stabilityThreshold: 200 },
+  });
+
+  watcher.on("all", (action, filePath) => {
+    const relative = path.relative(process.cwd(), filePath);
+    if (action === "add" || action === "change") {
+      schedule(filePath);
+    }
+    if (action === "unlink") {
+      schedule(filePath);
+    }
+    const event = { event: "watch", path: relative, action };
+    if (emit) emit(event);
+    logger.info("watch-event", event);
+  });
+
+  watcher.on("error", (error) => {
+    const err = error instanceof Error ? error : new Error(String(error));
+    logger.error("watch-error", { error: err.message });
+  });
+
+  activeWatchers.add(watcher);
+
+  return {
+    watching: watchRoots,
+  };
+}
+
+export async function closeWatchers(): Promise<void> {
+  await Promise.all(Array.from(activeWatchers).map((watcher) => watcher.close()));
+  activeWatchers.clear();
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,59 @@
+export type ChunkType = "pdf" | "markdown" | "text" | "word" | "pages";
+
+export interface Chunk {
+  id: string;
+  path: string;
+  type: ChunkType;
+  page?: number;
+  offsetStart?: number;
+  offsetEnd?: number;
+  text: string;
+  tokens?: number;
+  tags?: string[];
+  partial?: boolean;
+  mtime: number;
+}
+
+export interface Citation {
+  filePath: string;
+  page?: number;
+  startChar?: number;
+  endChar?: number;
+  snippet: string;
+}
+
+export interface SearchHit {
+  chunkId: string;
+  score: number;
+  text: string;
+  citation: Citation;
+}
+
+export interface RootsConfig {
+  roots: string[];
+  include: string[];
+  exclude: string[];
+}
+
+export interface IndexConfig {
+  chunkSize: number;
+  chunkOverlap: number;
+  ocrEnabled: boolean;
+  ocrTriggerMinChars: number;
+  useSQLiteVSS: boolean;
+  model: string;
+  maxFileSizeMB?: number;
+  concurrency?: number;
+  languages?: string[];
+}
+
+export interface OutConfig {
+  dataDir: string;
+  modelCacheDir?: string;
+}
+
+export interface AppConfig {
+  roots: RootsConfig;
+  index: IndexConfig;
+  out: OutConfig;
+}

--- a/src/types/pdf-parse.d.ts
+++ b/src/types/pdf-parse.d.ts
@@ -1,0 +1,5 @@
+declare module "pdf-parse/lib/pdf-parse.js" {
+  import { Buffer } from "buffer";
+  function pdfParse(data: Buffer, options?: Record<string, unknown>): Promise<any>;
+  export default pdfParse;
+}

--- a/src/types/sqlite3.d.ts
+++ b/src/types/sqlite3.d.ts
@@ -1,0 +1,1 @@
+declare module "sqlite3";

--- a/src/utils/cite.ts
+++ b/src/utils/cite.ts
@@ -1,0 +1,23 @@
+export interface SnippetOptions {
+  maxLength?: number;
+}
+
+export function buildSnippet(text: string, start: number | undefined, end: number | undefined, options: SnippetOptions = {}): string {
+  const maxLength = options.maxLength ?? 240;
+  const clean = text.replace(/[\u0000-\u001f]+/g, " ");
+  if (start === undefined || end === undefined || start < 0 || end > clean.length) {
+    return clean.slice(0, maxLength).trim();
+  }
+  const center = Math.floor((start + end) / 2);
+  const half = Math.floor(maxLength / 2);
+  const snippetStart = Math.max(0, center - half);
+  const snippetEnd = Math.min(clean.length, snippetStart + maxLength);
+  let snippet = clean.slice(snippetStart, snippetEnd).trim();
+  if (snippetStart > 0) {
+    snippet = `…${snippet}`;
+  }
+  if (snippetEnd < clean.length) {
+    snippet = `${snippet}…`;
+  }
+  return snippet;
+}

--- a/src/utils/fs-guard.ts
+++ b/src/utils/fs-guard.ts
@@ -1,0 +1,64 @@
+import { promises as fs } from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+export interface RootsGuardConfig {
+  roots: string[];
+}
+
+export interface GuardedPath {
+  absolute: string;
+  relative: string;
+}
+
+async function normalizeRoot(rootPath: string): Promise<string> {
+  const resolved = path.resolve(process.cwd(), rootPath);
+  try {
+    return await fs.realpath(resolved);
+  } catch {
+    return resolved;
+  }
+}
+
+export async function prepareRoots(config: RootsGuardConfig): Promise<string[]> {
+  const results: string[] = [];
+  for (const root of config.roots) {
+    results.push(await normalizeRoot(root));
+  }
+  return results;
+}
+
+export function toPosix(p: string): string {
+  return p.split(path.sep).join("/");
+}
+
+export async function guardPath(p: string, roots: string[]): Promise<GuardedPath> {
+  const abs = path.resolve(process.cwd(), p);
+  const real = await fs.realpath(abs).catch(() => abs);
+  for (const root of roots) {
+    const resRoot = await fs.realpath(root).catch(() => root);
+    const relative = path.relative(resRoot, real);
+    if (!relative.startsWith("..") && !path.isAbsolute(relative)) {
+      const repoRelative = path.relative(process.cwd(), real);
+      return { absolute: real, relative: toPosix(repoRelative) };
+    }
+  }
+  throw new Error(`Path ${p} is outside of configured roots`);
+}
+
+export async function ensureNotSymlink(p: string): Promise<void> {
+  const stat = await fs.lstat(p);
+  if (stat.isSymbolicLink()) {
+    throw new Error(`Symlinks are not allowed: ${p}`);
+  }
+}
+
+export async function ensureFileWithinRoots(p: string, roots: string[]): Promise<GuardedPath> {
+  const guarded = await guardPath(p, roots);
+  await ensureNotSymlink(guarded.absolute);
+  return guarded;
+}
+
+export function filePathFromUrl(url: string): string {
+  return fileURLToPath(new URL(url));
+}

--- a/src/utils/hash.ts
+++ b/src/utils/hash.ts
@@ -1,0 +1,17 @@
+import crypto from "crypto";
+import { v5 as uuidv5 } from "uuid";
+
+const BASE_NAMESPACE = uuidv5("https://narconations.org/mcp-nn", uuidv5.URL);
+
+export function sha1(data: string | Buffer): string {
+  return crypto.createHash("sha1").update(data).digest("hex");
+}
+
+export function chunkNamespace(path: string): string {
+  return uuidv5(path, BASE_NAMESPACE);
+}
+
+export function chunkId(path: string, page: number | undefined, start: number | undefined): string {
+  const scope = [path, page ?? "", start ?? ""].join("::");
+  return uuidv5(scope, chunkNamespace(path));
+}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,47 @@
+import { createWriteStream } from "fs";
+import { Writable } from "stream";
+
+type LogLevel = "debug" | "info" | "warn" | "error";
+
+interface LogEntry {
+  level: LogLevel;
+  msg: string;
+  time: string;
+  pid: number;
+  meta?: Record<string, unknown>;
+}
+
+const LOG_LEVELS: LogLevel[] = ["debug", "info", "warn", "error"];
+
+const envLevel = (process.env.MCP_NN_LOG_LEVEL ?? "info").toLowerCase();
+const levelIndex = Math.max(0, LOG_LEVELS.indexOf(envLevel as LogLevel));
+
+const stream: Writable = process.stdout instanceof Writable ? process.stdout : createWriteStream("/dev/stdout");
+
+function shouldLog(level: LogLevel): boolean {
+  if (level === "debug" && process.env.NODE_ENV !== "development" && process.env.DEBUG !== "1") {
+    return false;
+  }
+  return LOG_LEVELS.indexOf(level) >= levelIndex;
+}
+
+export function log(level: LogLevel, msg: string, meta: Record<string, unknown> = {}): void {
+  if (!shouldLog(level)) {
+    return;
+  }
+  const entry: LogEntry = {
+    level,
+    msg,
+    time: new Date().toISOString(),
+    pid: process.pid,
+    ...(Object.keys(meta).length ? { meta } : {}),
+  };
+  stream.write(JSON.stringify(entry) + "\n");
+}
+
+export const logger = {
+  debug: (msg: string, meta: Record<string, unknown> = {}) => log("debug", msg, meta),
+  info: (msg: string, meta: Record<string, unknown> = {}) => log("info", msg, meta),
+  warn: (msg: string, meta: Record<string, unknown> = {}) => log("warn", msg, meta),
+  error: (msg: string, meta: Record<string, unknown> = {}) => log("error", msg, meta),
+};

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,0 +1,1 @@
+export const now = () => Date.now();

--- a/tests/chunk.test.ts
+++ b/tests/chunk.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { chunkText } from "../src/pipeline/chunk.js";
+
+describe("chunkText", () => {
+  it("splits text into overlapping windows without truncating sentences", () => {
+    const text = `Paragraph one discusses Antwerp's role in European trafficking. Paragraph two expands on the logistics hub. Paragraph three considers enforcement gaps.`;
+    const fragments = chunkText(text, { chunkSize: 60, chunkOverlap: 10 });
+    expect(fragments.length).toBeGreaterThan(1);
+    for (const fragment of fragments) {
+      expect(fragment.text.length).toBeLessThanOrEqual(70);
+      expect(fragment.start).toBeLessThan(fragment.end);
+    }
+    expect(fragments.map((f) => f.start)).toStrictEqual([...fragments.map((f) => f.start)].sort((a, b) => a - b));
+  });
+});

--- a/tests/fixtures/corpus/note.md
+++ b/tests/fixtures/corpus/note.md
@@ -1,0 +1,10 @@
+---
+title: Antwerp Port
+tags:
+  - ports
+  - cocaine
+---
+
+# Antwerp Port Intel
+
+The port of Antwerp is a major hub for cocaine trafficking into Europe. Intelligence reports note increased activity in 2023.

--- a/tests/fixtures/corpus/summary.txt
+++ b/tests/fixtures/corpus/summary.txt
@@ -1,0 +1,1 @@
+Antwerp's port authorities intercepted multiple cocaine shipments in 2023. Criminal networks adapt quickly to enforcement changes.

--- a/tests/index-search.test.ts
+++ b/tests/index-search.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm } from "fs/promises";
+import os from "os";
+import path from "path";
+import { AppConfig } from "../src/types.js";
+import { Store } from "../src/store/store.js";
+import { getEmbedder } from "../src/pipeline/embed.js";
+import { reindex } from "../src/tools/reindex.js";
+import { searchLocal } from "../src/tools/searchLocal.js";
+import { getDoc } from "../src/tools/getDoc.js";
+
+const fixtureRoot = path.resolve("tests/fixtures/corpus");
+
+interface TestContext {
+  config: AppConfig;
+  store: Store;
+  embedder: ReturnType<typeof getEmbedder>;
+}
+
+describe("reindex and search", () => {
+  let tmpDir: string;
+  let context: TestContext;
+
+  beforeEach(async () => {
+    process.env.MCP_NN_EMBED_FAKE = "1";
+    tmpDir = await mkdtemp(path.join(os.tmpdir(), "mcp-nn-test-"));
+    const config: AppConfig = {
+      roots: {
+        roots: [fixtureRoot],
+        include: [".md", ".txt"],
+        exclude: [],
+      },
+      index: {
+        chunkSize: 200,
+        chunkOverlap: 40,
+        ocrEnabled: false,
+        ocrTriggerMinChars: 100,
+        useSQLiteVSS: false,
+        model: "Xenova/all-MiniLM-L6-v2",
+        maxFileSizeMB: 5,
+        concurrency: 1,
+        languages: ["eng"],
+      },
+      out: {
+        dataDir: tmpDir,
+      },
+    };
+    const store = await Store.load(config);
+    const embedder = getEmbedder(config);
+    context = { config, store, embedder };
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("indexes fixture corpus and returns search results", async () => {
+    const stats = await reindex(context, {});
+    expect(stats.indexed + stats.updated).toBeGreaterThan(0);
+
+    const result = await searchLocal(context, { query: "cocaine Antwerp", k: 4, alpha: 0.5 });
+    expect(result.results.length).toBeGreaterThan(0);
+    const first = result.results[0];
+    expect(first.citation.filePath).toContain("tests/fixtures/corpus");
+
+    const doc = await getDoc(context, { path: first.citation.filePath });
+    expect(doc.text.length).toBeGreaterThan(10);
+  });
+});

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -1,0 +1,7 @@
+import { describe, it, expect } from 'vitest';
+
+describe('smoke test', () => {
+  it('runs test suite', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ESNext",
+    "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "resolveJsonModule": true,
     "esModuleInterop": true,
@@ -10,6 +10,6 @@
     "strict": true,
     "types": ["node"]
   },
-  "include": ["src/**/*.ts"],
+  "include": ["src/**/*.ts", "src/types/**/*.d.ts", "tests/**/*.ts"],
   "ts-node": { "esm": true }
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "installCommand": "npm install",
+  "buildCommand": "npm run build",
+  "framework": null,
+  "outputDirectory": "dist",
+  "env": {
+    "NODE_OPTIONS": "--enable-source-maps"
+  }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["tests/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Summary
- document the offline MCP quickstart, chat export workflow, and operational notes for NarcoNations.org
- implement configuration, indexing, embedding, and storage layers to handle PDFs, Markdown, text, Word, and Pages content with hybrid retrieval
- expose MCP tools (search_local, get_doc, reindex, watch, stats, import_chatgpt_export), supporting scripts, and tests for end-to-end indexing

## Testing
- npm run build
- npm test
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68ce2b69f94c83279d381836b9fadcfc